### PR TITLE
feat: Upgrade to Tractus-X EDC 0.11.2 (Eclipse EDC 0.14.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Adjust the EDC and CDK configuration in [`environments.ts`](https://github.com/a
 ...
 Outputs:
 DataspaceConnectorStack.EdcApiDataPlaneApiEndpoint     = https://<api-id>.execute-api.<aws-region>.amazonaws.com/data/
-DataspaceConnectorStack.EdcApiDspApiEndpoint           = https://<api-id>.execute-api.<aws-region>.amazonaws.com/dsp/
+DataspaceConnectorStack.EdcApiDspApiEndpoint           = https://<api-id>.execute-api.<aws-region>.amazonaws.com/protocol/
 DataspaceConnectorStack.EdcApiManagementApiEndpoint    = https://<api-id>.execute-api.<aws-region>.amazonaws.com/management/
 DataspaceConnectorStack.EdcApiObservabilityApiEndpoint = https://<api-id>.execute-api.<aws-region>.amazonaws.com/status/
 DataspaceConnectorStack.EdcOauthClientSecretArn        = arn:aws:secretsmanager:<aws-region>:<account-id>:secret:edc.iam.sts.oauth.client.secret
@@ -34,6 +34,14 @@ DataspaceConnectorStack.EdcOauthClientSecretArn        = arn:aws:secretsmanager:
 After deployment, navigate to the [AWS Secrets Manager console](https://console.aws.amazon.com/secretsmanager/listsecrets) and update `EdcOauthClientSecretArn`'s value with your OAuth client secret obtained from the Cofinity-X Portal.
 
 ✨ That's it! You can now interact with your EDC's management API to start creating contract offers or browse a data space participant's catalog. 
+
+## AI-Assisted Connector Management
+
+This project includes tooling for AI-assisted deployment and operation of your connector:
+
+* **[MCP Server](mcp/)** — A Model Context Protocol server with 15 tools for interacting with the EDC Management API. Create assets, negotiate contracts, transfer data, and troubleshoot issues — all through natural language in any MCP-compatible AI assistant.
+
+* **[Kiro Power](kiro-power/)** — Guided workflows for [Kiro](https://kiro.dev) that walk you through deploying your connector from scratch and validating end-to-end data exchange. Includes step-by-step steering files for deployment configuration, MCP setup, and S3 loopback testing.
 
 ## Architecture
 
@@ -50,7 +58,7 @@ After deployment, navigate to the [AWS Secrets Manager console](https://console.
 
 ### Custom Domain (Optional)
 
-By default, the EDC APIs are exposed via auto-generated API Gateway URLs (e.g. `https://<api-id>.execute-api.<region>.amazonaws.com/dsp/`). To use your own domain instead, you need:
+By default, the EDC APIs are exposed via auto-generated API Gateway URLs (e.g. `https://<api-id>.execute-api.<region>.amazonaws.com/protocol/`). To use your own domain instead, you need:
 
 1. A [Route 53 hosted zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html) for your domain
 2. An [ACM certificate](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html) in `us-east-1` (required for edge-optimized API Gateway endpoints, regardless of your stack's deployment region)
@@ -67,7 +75,7 @@ All three values are required when enabling a custom domain. This will:
 - Create an API Gateway custom domain with TLS 1.2
 - Create a Route 53 A record pointing to the API Gateway
 - Disable the default `execute-api` endpoints
-- Map all EDC APIs as base paths: `/status`, `/management`, `/dsp`, `/data`
+- Map all EDC APIs as base paths: `/status`, `/management`, `/protocol`, `/data`
 - Automatically configure the EDC's DSP callback and data plane public URLs to use your domain
 
 ### Management API Authentication
@@ -123,7 +131,6 @@ Stores credentials needed to access data sources and destinations during transfe
 
 ## Backlog / Ideas 💡
 
-* Upgrade to Tractus-X EDC 0.11.x (Saturn)
 * Configurable switch between DynamoDB and Aurora PostgreSQL for control plane persistance
 * Include examples for EDC assets, such as OAuth 2.0 and S3
 * Configurable control and data plane auto-scaling on ECS Service level

--- a/cdk/api/dsp-api.yaml
+++ b/cdk/api/dsp-api.yaml
@@ -3,6 +3,1587 @@
 
 openapi: 3.0.1
 paths:
+  /.well-known/dspace-version:
+    get:
+      operationId: getProtocolVersions
+      parameters:
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      x-amazon-apigateway-integration:
+        type: mock
+        passthroughBehavior: never
+        requestTemplates:
+          application/json: '{"statusCode": 200}
+
+            '
+        responses:
+          2\d{2}:
+            statusCode: 200
+            responseTemplates:
+              application/json: "{\n  \"Success\": true\n}\n"
+  /2024/1/catalog/datasets/{id}:
+    get:
+      operationId: getDataset
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/catalog/datasets/{id}
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/catalog/request:
+    post:
+      operationId: requestCatalog
+      parameters:
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: continuationToken
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/catalog/request
+  /2024/1/negotiations/offer:
+    post:
+      operationId: initialContractOffer
+      parameters:
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/negotiations/offer
+  /2024/1/negotiations/request:
+    post:
+      operationId: initialContractRequest
+      parameters:
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/negotiations/request
+  /2024/1/negotiations/{id}:
+    get:
+      operationId: getNegotiation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/negotiations/{id}
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/negotiations/{id}/agreement:
+    post:
+      operationId: createAgreement
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/negotiations/{id}/agreement
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/negotiations/{id}/agreement/verification:
+    post:
+      operationId: verifyAgreement
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/negotiations/{id}/agreement/verification
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/negotiations/{id}/events:
+    post:
+      operationId: createEvent
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/negotiations/{id}/events
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/negotiations/{id}/offer:
+    post:
+      operationId: providerOffer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/negotiations/{id}/offer
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/negotiations/{id}/request:
+    post:
+      operationId: contractRequest
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/negotiations/{id}/request
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/negotiations/{id}/termination:
+    post:
+      operationId: terminateNegotiation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/negotiations/{id}/termination
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/transfers/request:
+    post:
+      operationId: initiateTransferProcess
+      parameters:
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/transfers/request
+  /2024/1/transfers/{id}:
+    get:
+      operationId: getTransferProcess
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/transfers/{id}
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/transfers/{id}/completion:
+    post:
+      operationId: transferProcessCompletion
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/transfers/{id}/completion
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/transfers/{id}/start:
+    post:
+      operationId: transferProcessStart
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/transfers/{id}/start
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/transfers/{id}/suspension:
+    post:
+      operationId: transferProcessSuspension
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/transfers/{id}/suspension
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2024/1/transfers/{id}/termination:
+    post:
+      operationId: transferProcessTermination
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2024/1/transfers/{id}/termination
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/catalog/datasets/{id}:
+    get:
+      operationId: getDataset
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/catalog/datasets/{id}
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/catalog/request:
+    post:
+      operationId: requestCatalog
+      parameters:
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: continuationToken
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/catalog/request
+  /2025-1/negotiations/offers:
+    post:
+      operationId: initialContractOffer
+      parameters:
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/negotiations/offers
+  /2025-1/negotiations/request:
+    post:
+      operationId: initialContractRequest
+      parameters:
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/negotiations/request
+  /2025-1/negotiations/{id}:
+    get:
+      operationId: getNegotiation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/negotiations/{id}
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/negotiations/{id}/agreement:
+    post:
+      operationId: createAgreement
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/negotiations/{id}/agreement
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/negotiations/{id}/agreement/verification:
+    post:
+      operationId: verifyAgreement
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/negotiations/{id}/agreement/verification
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/negotiations/{id}/events:
+    post:
+      operationId: createEvent
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/negotiations/{id}/events
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/negotiations/{id}/offers:
+    post:
+      operationId: providerOffer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/negotiations/{id}/offers
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/negotiations/{id}/request:
+    post:
+      operationId: contractRequest
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/negotiations/{id}/request
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/negotiations/{id}/termination:
+    post:
+      operationId: terminateNegotiation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/negotiations/{id}/termination
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/transfers/request:
+    post:
+      operationId: initiateTransferProcess
+      parameters:
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/transfers/request
+  /2025-1/transfers/{id}:
+    get:
+      operationId: getTransferProcess
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/transfers/{id}
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/transfers/{id}/completion:
+    post:
+      operationId: transferProcessCompletion
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/transfers/{id}/completion
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/transfers/{id}/start:
+    post:
+      operationId: transferProcessStart
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/transfers/{id}/start
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/transfers/{id}/suspension:
+    post:
+      operationId: transferProcessSuspension
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/transfers/{id}/suspension
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /2025-1/transfers/{id}/termination:
+    post:
+      operationId: transferProcessTermination
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                empty:
+                  type: boolean
+                valueType:
+                  type: string
+                  enum:
+                    - ARRAY
+                    - OBJECT
+                    - STRING
+                    - NUMBER
+                    - "TRUE"
+                    - "FALSE"
+                    - "NULL"
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/protocol/2025-1/transfers/{id}/termination
+        requestParameters:
+          integration.request.path.id: method.request.path.id
   /catalog/datasets/{id}:
     get:
       operationId: getDataset
@@ -22,13 +1603,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: GET
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/catalog/datasets/{id}
+        uri: http://${loadBalancerDnsName}/api/protocol/catalog/datasets/{id}
   /catalog/request:
     post:
       operationId: requestCatalog
@@ -47,7 +1628,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -67,11 +1648,11 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/catalog/request
+        uri: http://${loadBalancerDnsName}/api/protocol/catalog/request
   /negotiations/offer:
     post:
       operationId: initialContractOffer
@@ -86,7 +1667,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -106,11 +1687,11 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/negotiations/offer
+        uri: http://${loadBalancerDnsName}/api/protocol/negotiations/offer
   /negotiations/request:
     post:
       operationId: initialContractRequest
@@ -125,7 +1706,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -145,11 +1726,11 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/negotiations/request
+        uri: http://${loadBalancerDnsName}/api/protocol/negotiations/request
   /negotiations/{id}:
     get:
       operationId: getNegotiation
@@ -169,13 +1750,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: GET
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/negotiations/{id}
+        uri: http://${loadBalancerDnsName}/api/protocol/negotiations/{id}
   /negotiations/{id}/agreement:
     post:
       operationId: createAgreement
@@ -195,7 +1776,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -215,13 +1796,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/negotiations/{id}/agreement
+        uri: http://${loadBalancerDnsName}/api/protocol/negotiations/{id}/agreement
   /negotiations/{id}/agreement/verification:
     post:
       operationId: verifyAgreement
@@ -241,7 +1822,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -261,13 +1842,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/negotiations/{id}/agreement/verification
+        uri: http://${loadBalancerDnsName}/api/protocol/negotiations/{id}/agreement/verification
   /negotiations/{id}/events:
     post:
       operationId: createEvent
@@ -287,7 +1868,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -307,13 +1888,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/negotiations/{id}/events
+        uri: http://${loadBalancerDnsName}/api/protocol/negotiations/{id}/events
   /negotiations/{id}/offer:
     post:
       operationId: providerOffer
@@ -333,7 +1914,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -353,13 +1934,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/negotiations/{id}/offer
+        uri: http://${loadBalancerDnsName}/api/protocol/negotiations/{id}/offer
   /negotiations/{id}/request:
     post:
       operationId: contractRequest
@@ -379,7 +1960,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -399,13 +1980,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/negotiations/{id}/request
+        uri: http://${loadBalancerDnsName}/api/protocol/negotiations/{id}/request
   /negotiations/{id}/termination:
     post:
       operationId: terminateNegotiation
@@ -425,7 +2006,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -445,40 +2026,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/negotiations/{id}/termination
-  /.well-known/dspace-version:
-    get:
-      operationId: getProtocolVersions
-      parameters:
-        - in: header
-          name: Authorization
-          schema:
-            type: string
-      responses:
-        default:
-          content:
-            application/json: {}
-          description: default response
-      x-amazon-apigateway-integration:
-        type: mock
-        passthroughBehavior: never
-        requestTemplates:
-          "application/json": |
-            {"statusCode": 200}
-        responses:
-          "2\\d{2}":
-            statusCode: 200
-            responseTemplates:
-              "application/json": |
-                {
-                  "Success": true
-                }
+        uri: http://${loadBalancerDnsName}/api/protocol/negotiations/{id}/termination
   /transfers/request:
     post:
       operationId: initiateTransferProcess
@@ -493,7 +2047,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -513,11 +2067,11 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/transfers/request
+        uri: http://${loadBalancerDnsName}/api/protocol/transfers/request
   /transfers/{id}:
     get:
       operationId: getTransferProcess
@@ -537,13 +2091,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: GET
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/transfers/{id}
+        uri: http://${loadBalancerDnsName}/api/protocol/transfers/{id}
   /transfers/{id}/completion:
     post:
       operationId: transferProcessCompletion
@@ -563,7 +2117,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -583,13 +2137,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/transfers/{id}/completion
+        uri: http://${loadBalancerDnsName}/api/protocol/transfers/{id}/completion
   /transfers/{id}/start:
     post:
       operationId: transferProcessStart
@@ -609,7 +2163,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -629,13 +2183,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/transfers/{id}/start
+        uri: http://${loadBalancerDnsName}/api/protocol/transfers/{id}/start
   /transfers/{id}/suspension:
     post:
       operationId: transferProcessSuspension
@@ -655,7 +2209,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -675,13 +2229,13 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/transfers/{id}/suspension
+        uri: http://${loadBalancerDnsName}/api/protocol/transfers/{id}/suspension
   /transfers/{id}/termination:
     post:
       operationId: transferProcessTermination
@@ -701,7 +2255,7 @@ paths:
             schema:
               type: object
               additionalProperties:
-                $ref: "#/components/schemas/JsonValue"
+                type: object
               properties:
                 empty:
                   type: boolean
@@ -721,42 +2275,10 @@ paths:
             application/json: {}
           description: default response
       x-amazon-apigateway-integration:
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         httpMethod: POST
         requestParameters:
           integration.request.path.id: method.request.path.id
         type: http_proxy
-        uri: http://${loadBalancerDnsName}/api/v1/dsp/transfers/{id}/termination
-components:
-  schemas:
-    JsonObject:
-      type: object
-      additionalProperties:
-        $ref: "#/components/schemas/JsonValue"
-      properties:
-        empty:
-          type: boolean
-        valueType:
-          type: string
-          enum:
-            - ARRAY
-            - OBJECT
-            - STRING
-            - NUMBER
-            - "TRUE"
-            - "FALSE"
-            - "NULL"
-    JsonValue:
-      type: object
-      properties:
-        valueType:
-          type: string
-          enum:
-            - ARRAY
-            - OBJECT
-            - STRING
-            - NUMBER
-            - "TRUE"
-            - "FALSE"
-            - "NULL"
+        uri: http://${loadBalancerDnsName}/api/protocol/transfers/{id}/termination

--- a/cdk/api/management-api.yaml
+++ b/cdk/api/management-api.yaml
@@ -3,145 +3,6 @@
 
 openapi: 3.0.1
 paths:
-  /callback/{processId}/deprovision:
-    post:
-      operationId: callDeprovisionWebhook
-      parameters:
-        - in: path
-          name: processId
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DeprovisionedResource"
-      responses:
-        default:
-          content:
-            application/json: {}
-          description: default response
-      tags:
-        - HTTP Provisioner Webhook
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/callback/{processId}/deprovision
-  /callback/{processId}/provision:
-    post:
-      operationId: callProvisionWebhook
-      parameters:
-        - in: path
-          name: processId
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ProvisionerWebhookRequest"
-      responses:
-        default:
-          content:
-            application/json: {}
-          description: default response
-      tags:
-        - HTTP Provisioner Webhook
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/callback/{processId}/provision
-  /v3/assets:
-    post:
-      description: Creates a new asset together with a data address
-      operationId: createAssetV3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AssetInput"
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/IdResponse"
-          description:
-            Asset was created successfully. Returns the asset Id and created
-            timestamp
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: Request body was malformed
-        "409":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description:
-            "Could not create asset, because an asset with that ID already\
-            \ exists"
-      tags:
-        - Asset V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: "http://${loadBalancerDnsName}/management/v3/assets"
-    put:
-      description:
-        "Updates an asset with the given ID if it exists. If the asset\
-        \ is not found, no further action is taken. DANGER ZONE: Note that updating\
-        \ assets can have unexpected results, especially for contract offers that\
-        \ have been sent out or are ongoing in contract negotiations."
-      operationId: updateAssetV3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AssetInput"
-      responses:
-        "204":
-          description: Asset was updated successfully
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          description: "Asset could not be updated, because it does not exist."
-      tags:
-        - Asset V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: PUT
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: "http://${loadBalancerDnsName}/management/v3/assets"
   /v3/assets/request:
     post:
       description: Request all assets according to a particular query
@@ -150,7 +11,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/QuerySpec"
+              type: object
       responses:
         "200":
           content:
@@ -158,7 +19,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/AssetOutput"
+                  type: object
           description: The assets matching the query
         "400":
           content:
@@ -166,7 +27,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: Request body was malformed
       tags:
         - Asset V3
@@ -175,17 +36,15 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
-        uri: "http://${loadBalancerDnsName}/management/v3/assets/request"
+        uri: http://${loadBalancerDnsName}/api/management/v3/assets/request
   /v3/assets/{id}:
     delete:
       description:
-        "Removes an asset with the given ID if possible. Deleting an asset\
-        \ is only possible if that asset is not yet referenced by a contract agreement,\
-        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
-        \ can have unexpected results, especially for contract offers that have been\
-        \ sent out or ongoing or contract negotiations."
+        "Removes an asset with the given ID if possible. Deleting an asset is only possible if that asset is not
+        yet referenced by a contract agreement, in which case an error is returned. DANGER ZONE: Note that deleting assets
+        can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations."
       operationId: removeAssetV3
       parameters:
         - in: path
@@ -202,15 +61,15 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: An asset with the given ID does not exist
         "409":
           content:
@@ -218,10 +77,8 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description:
-            "The asset cannot be deleted, because it is referenced by a\
-            \ contract agreement"
+                  type: object
+          description: The asset cannot be deleted, because it is referenced by a contract agreement
       tags:
         - Asset V3
       x-amazon-apigateway-auth:
@@ -229,11 +86,11 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: DELETE
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         requestParameters:
           integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/assets/{id}
+        uri: http://${loadBalancerDnsName}/api/management/v3/assets/{id}
     get:
       description: Gets an asset with the given ID
       operationId: getAssetV3
@@ -248,7 +105,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AssetOutput"
+                type: object
           description: The asset
         "400":
           content:
@@ -256,15 +113,15 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: An asset with the given ID does not exist
       tags:
         - Asset V3
@@ -273,70 +130,136 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: GET
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         requestParameters:
           integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/assets/{id}
-  /v3/catalog/dataset/request:
+        uri: http://${loadBalancerDnsName}/api/management/v3/assets/{id}
+  /callback/{processId}/provision:
     post:
-      operationId: getDatasetV3
+      operationId: callProvisionWebhook
+      parameters:
+        - in: path
+          name: processId
+          required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DatasetRequest"
+              type: object
       responses:
         default:
           content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Dataset"
-          description: Gets single dataset from a connector
+            application/json: {}
+          description: default response
       tags:
-        - Catalog V3
+        - HTTP Provisioner Webhook
       x-amazon-apigateway-auth:
         type: AWS_IAM
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/catalog/dataset/request
-  /v3/catalog/request:
+        uri: http://${loadBalancerDnsName}/api/management/callback/{processId}/provision
+  /v3/contractnegotiations/{id}/agreement:
+    get:
+      description: Gets a contract agreement for a contract negotiation with the given ID
+      operationId: getAgreementForNegotiationV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: The contract agreement that is attached to the negotiation, or null
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: An contract negotiation with the given ID does not exist
+      tags:
+        - Contract Negotiation V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: GET
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractnegotiations/{id}/agreement
+  /v3/contractnegotiations:
     post:
-      operationId: requestCatalogV3
+      description:
+        Initiates a contract negotiation for a given offer and with the given counter part. Please note that successfully
+        invoking this endpoint only means that the negotiation was initiated. Clients must poll the /{id}/state endpoint to
+        track the state
+      operationId: initiateContractNegotiationV3
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CatalogRequest"
+              type: object
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Catalog"
-          description: Gets contract offers (=catalog) of a single connector
+                type: object
+          description: The negotiation was successfully initiated. Returns the contract negotiation ID and created timestamp
+          links:
+            poll-state:
+              operationId: getNegotiationStateV3
+              parameters:
+                id: $response.body#/id
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request body was malformed
       tags:
-        - Catalog V3
+        - Contract Negotiation V3
       x-amazon-apigateway-auth:
         type: AWS_IAM
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/catalog/request
-  /v3/contractagreements/request:
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractnegotiations
+  /v3/contractdefinitions/request:
     post:
-      description: Gets all contract agreements according to a particular query
-      operationId: queryAgreementsV3
+      description: Returns all contract definitions according to a query
+      operationId: queryContractDefinitionsV3
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/QuerySpec"
+              type: object
       responses:
         "200":
           content:
@@ -344,26 +267,26 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ContractAgreement"
-          description: The contract agreements matching the query
+                  type: object
+          description: The contract definitions matching the query
         "400":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: Request body was malformed
+                  type: object
+          description: Request was malformed
       tags:
-        - Contract Agreement V3
+        - Contract Definition V3
       x-amazon-apigateway-auth:
         type: AWS_IAM
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/contractagreements/request
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractdefinitions/request
   /v3/contractagreements/{id}:
     get:
       description: Gets an contract agreement with the given ID
@@ -379,7 +302,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContractAgreement"
+                type: object
           description: The contract agreement
         "400":
           content:
@@ -387,15 +310,15 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: An contract agreement with the given ID does not exist
       tags:
         - Contract Agreement V3
@@ -404,311 +327,58 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: GET
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         requestParameters:
           integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/contractagreements/{id}
-  /v3/contractagreements/{id}/negotiation:
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractagreements/{id}
+  /v3/edrs/{transferProcessId}/dataaddress:
     get:
-      description: Gets a contract negotiation with the given contract agreement ID
-      operationId: getNegotiationByAgreementIdV3
+      tags:
+        - EDR Cache V3
+      description: Gets the EDR data address with the given transfer process ID
+      operationId: getEdrEntryDataAddressV3
       parameters:
-        - in: path
-          name: id
+        - name: transferProcessId
+          in: path
           required: true
+          style: simple
+          explode: false
           schema:
             type: string
       responses:
         "200":
+          description: The data address
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContractNegotiation"
-          description: The contract negotiation
+                type: object
         "400":
+          description: Request was malformed, e.g. id was null
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
         "404":
+          description: An EDR data address with the given transfer process ID does not exist
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: An contract agreement with the given ID does not exist
-      tags:
-        - Contract Agreement V3
+                  type: object
       x-amazon-apigateway-auth:
         type: AWS_IAM
       x-amazon-apigateway-integration:
         type: http_proxy
-        httpMethod: GET
-        connectionId: "${vpcLinkId}"
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/edrs/{transferProcessId}/dataaddress
         requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/contractagreements/{id}/negotiation
-  /v3/contractdefinitions:
-    post:
-      description: Creates a new contract definition
-      operationId: createContractDefinitionV3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ContractDefinitionInput"
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/IdResponse"
-          description:
-            contract definition was created successfully. Returns the Contract
-            Definition Id and created timestamp
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: Request body was malformed
-        "409":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description:
-            "Could not create contract definition, because a contract definition\
-            \ with that ID already exists"
-      tags:
-        - Contract Definition V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/contractdefinitions
-    put:
-      description:
-        Updated a contract definition with the given ID. The supplied JSON
-        structure must be a valid JSON-LD object
-      operationId: updateContractDefinitionV3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ContractDefinitionInput"
-      responses:
-        "204":
-          description: Contract definition was updated successfully
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: A contract definition with the given ID does not exist
-      tags:
-        - Contract Definition V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: PUT
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/contractdefinitions
-  /v3/contractdefinitions/request:
-    post:
-      description: Returns all contract definitions according to a query
-      operationId: queryContractDefinitionsV3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/QuerySpec"
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ContractDefinitionOutput"
-          description: The contract definitions matching the query
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: Request was malformed
-      tags:
-        - Contract Definition V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/contractdefinitions/request
-  /v3/contractdefinitions/{id}:
-    delete:
-      description:
-        "Removes a contract definition with the given ID if possible. DANGER\
-        \ ZONE: Note that deleting contract definitions can have unexpected results,\
-        \ especially for contract offers that have been sent out or ongoing or contract\
-        \ negotiations."
-      operationId: deleteContractDefinitionV3
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "204":
-          description: Contract definition was deleted successfully
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: A contract definition with the given ID does not exist
-      tags:
-        - Contract Definition V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: DELETE
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/contractdefinitions/{id}
-    get:
-      description: Gets an contract definition with the given ID
-      operationId: getContractDefinitionV3
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ContractDefinitionOutput"
-          description: The contract definition
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: An contract agreement with the given ID does not exist
-      tags:
-        - Contract Definition V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: GET
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/contractdefinitions/{id}
-  /v3/contractnegotiations:
-    post:
-      description:
-        "Initiates a contract negotiation for a given offer and with the\
-        \ given counter part. Please note that successfully invoking this endpoint\
-        \ only means that the negotiation was initiated. Clients must poll the /{id}/state\
-        \ endpoint to track the state"
-      operationId: initiateContractNegotiationV3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ContractRequest"
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/IdResponse"
-          description:
-            The negotiation was successfully initiated. Returns the contract
-            negotiation ID and created timestamp
-          links:
-            poll-state:
-              operationId: getNegotiationStateV3
-              parameters:
-                id: $response.body#/id
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: Request body was malformed
-      tags:
-        - Contract Negotiation V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/contractnegotiations
+          integration.request.path.transferProcessId: method.request.path.transferProcessId
   /v3/contractnegotiations/request:
     post:
       description: Returns all contract negotiations according to a query
@@ -717,7 +387,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/QuerySpec"
+              type: object
       responses:
         "200":
           content:
@@ -725,7 +395,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ContractNegotiation"
+                  type: object
           description: The contract negotiations that match the query
         "400":
           content:
@@ -733,7 +403,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: Request was malformed
       tags:
         - Contract Negotiation V3
@@ -742,574 +412,9 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/contractnegotiations/request
-  /v3/contractnegotiations/{id}:
-    get:
-      description: Gets a contract negotiation with the given ID
-      operationId: getNegotiationV3
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ContractNegotiation"
-          description: The contract negotiation
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: An contract negotiation with the given ID does not exist
-      tags:
-        - Contract Negotiation V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: GET
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/contractnegotiations/{id}
-  /v3/contractnegotiations/{id}/agreement:
-    get:
-      description:
-        Gets a contract agreement for a contract negotiation with the given
-        ID
-      operationId: getAgreementForNegotiationV3
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ContractAgreement"
-          description:
-            "The contract agreement that is attached to the negotiation,\
-            \ or null"
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: An contract negotiation with the given ID does not exist
-      tags:
-        - Contract Negotiation V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: GET
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/contractnegotiations/{id}/agreement
-  /v3/contractnegotiations/{id}/state:
-    get:
-      description: Gets the state of a contract negotiation with the given ID
-      operationId: getNegotiationStateV3
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/NegotiationState"
-          description: The contract negotiation's state
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: An contract negotiation with the given ID does not exist
-      tags:
-        - Contract Negotiation V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: GET
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/contractnegotiations/{id}/state
-  /v3/contractnegotiations/{id}/terminate:
-    post:
-      description: Terminates the contract negotiation.
-      operationId: terminateNegotiationV3
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TerminateNegotiationSchema"
-      responses:
-        "200":
-          description: ContractNegotiation is terminating
-          links:
-            poll-state:
-              operationId: getNegotiationStateV3
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: Request was malformed
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: A contract negotiation with the given ID does not exist
-      tags:
-        - Contract Negotiation V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/contractnegotiations/{id}/terminate
-  /v3/dataplanes:
-    get:
-      description: Returns a list of all currently registered data plane instances
-      operationId: getAllDataPlaneInstancesV3
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/DataPlaneInstanceSchema"
-          description:
-            A (potentially empty) list of currently registered data plane
-            instances
-      tags:
-        - Dataplane Selector V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: GET
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/dataplanes
-  /v2/edrs/request:
-    post:
-      description: Request all Edr entries according to a particular query
-      operationId: requestEdrEntriesV3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/QuerySpec"
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/EndpointDataReferenceEntry"
-          description: The edr entries matching the query
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: Request body was malformed
-      tags:
-        - EDR Cache V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v2/edrs/request
-  /v2/edrs/{transferProcessId}:
-    delete:
-      description: Removes an EDR entry given the transfer process ID
-      operationId: removeEdrEntryV3
-      parameters:
-        - in: path
-          name: transferProcessId
-          required: true
-          schema:
-            type: string
-      responses:
-        "204":
-          description: EDR entry was deleted successfully
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: An EDR entry with the given ID does not exist
-      tags:
-        - EDR Cache V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: DELETE
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v2/edrs/{transferProcessId}
-  /v2/edrs/{transferProcessId}/dataaddress:
-    get:
-      deprecated: true
-      description: Gets the EDR data address with the given transfer process ID
-      operationId: getEdrEntryDataAddressV3
-      parameters:
-        - in: path
-          name: transferProcessId
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DataAddress"
-          description: The data address
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description:
-            An EDR data address with the given transfer process ID does
-            not exist
-      tags:
-        - EDR Cache V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: GET
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.transferProcessId: method.request.path.transferProcessId
-        uri: http://${loadBalancerDnsName}/management/v2/edrs/{transferProcessId}/dataaddress
-  /v3/policydefinitions:
-    post:
-      description: Creates a new policy definition
-      operationId: createPolicyDefinitionV3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PolicyDefinitionInput"
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/IdResponse"
-          description:
-            policy definition was created successfully. Returns the Policy
-            Definition Id and created timestamp
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: Request body was malformed
-        "409":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description:
-            "Could not create policy definition, because a contract definition\
-            \ with that ID already exists"
-      tags:
-        - Policy Definition V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/policydefinitions
-  /v3/policydefinitions/request:
-    post:
-      description: Returns all policy definitions according to a query
-      operationId: queryPolicyDefinitionsV3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/QuerySpec"
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/PolicyDefinitionOutput"
-          description: The policy definitions matching the query
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: Request was malformed
-      tags:
-        - Policy Definition V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/policydefinitions/request
-  /v3/policydefinitions/{id}:
-    delete:
-      description:
-        "Removes a policy definition with the given ID if possible. Deleting\
-        \ a policy definition is only possible if that policy definition is not yet\
-        \ referenced by a contract definition, in which case an error is returned.\
-        \ DANGER ZONE: Note that deleting policy definitions can have unexpected results,\
-        \ do this at your own risk!"
-      operationId: deletePolicyDefinitionV3
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "204":
-          description: Policy definition was deleted successfully
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: An policy definition with the given ID does not exist
-        "409":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description:
-            "The policy definition cannot be deleted, because it is referenced\
-            \ by a contract definition"
-      tags:
-        - Policy Definition V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: DELETE
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/policydefinitions/{id}
-    get:
-      description: Gets a policy definition with the given ID
-      operationId: getPolicyDefinitionV3
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PolicyDefinitionOutput"
-          description: The  policy definition
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: An  policy definition with the given ID does not exist
-      tags:
-        - Policy Definition V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: GET
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/policydefinitions/{id}
-    put:
-      description:
-        "Updates an existing Policy, If the Policy is not found, an error\
-        \ is reported"
-      operationId: updatePolicyDefinitionV3
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PolicyDefinitionInput"
-      responses:
-        "204":
-          description: policy definition was updated successfully.
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: Request body was malformed
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiErrorDetail"
-          description:
-            "policy definition could not be updated, because it does not\
-            \ exists"
-      tags:
-        - Policy Definition V3
-      x-amazon-apigateway-auth:
-        type: AWS_IAM
-      x-amazon-apigateway-integration:
-        type: http_proxy
-        httpMethod: PUT
-        connectionId: "${vpcLinkId}"
-        connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/policydefinitions/{id}
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractnegotiations/request
   /v3/secrets:
     post:
       description: Creates a new secret.
@@ -1318,23 +423,21 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretInput"
+              type: object
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IdResponse"
-          description:
-            Secret was created successfully. Returns the secret Id and
-            created timestamp
+                type: object
+          description: Secret was created successfully. Returns the secret Id and created timestamp
         "400":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: Request body was malformed
         "409":
           content:
@@ -1342,10 +445,8 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description:
-            "Could not create secret, because a secret with that ID already\
-            \ exists"
+                  type: object
+          description: Could not create secret, because a secret with that ID already exists
       tags:
         - Secret V3
       x-amazon-apigateway-auth:
@@ -1353,19 +454,17 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/secrets
+        uri: http://${loadBalancerDnsName}/api/management/v3/secrets
     put:
-      description:
-        "Updates a secret with the given ID if it exists. If the secret\
-        \ is not found, no further action is taken. "
+      description: "Updates a secret with the given ID if it exists. If the secret is not found, no further action is taken. "
       operationId: updateSecretV3
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretInput"
+              type: object
       responses:
         "204":
           description: Secret was updated successfully
@@ -1375,10 +474,10 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
-          description: "Secret could not be updated, because it does not exist."
+          description: Secret could not be updated, because it does not exist.
       tags:
         - Secret V3
       x-amazon-apigateway-auth:
@@ -1386,9 +485,184 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: PUT
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/secrets
+        uri: http://${loadBalancerDnsName}/api/management/v3/secrets
+  /v3/transferprocesses/{id}/suspend:
+    post:
+      description:
+        Requests the suspension of a transfer process. Due to the asynchronous nature of transfers, a successful
+        response only indicates that the request was successfully received. This may take a long time, so clients must poll
+        the /{id}/state endpoint to track the state.
+      operationId: suspendTransferProcessV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "204":
+          description: Request to suspend the transfer process was successfully received
+          links:
+            poll-state:
+              operationId: suspendTransferProcessV3
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: A transfer process with the given ID does not exist
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Could not suspend the transfer process, because it is already completed or terminated.
+      tags:
+        - Transfer Process V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/transferprocesses/{id}/suspend
+  /v3/contractdefinitions:
+    post:
+      description: Creates a new contract definition
+      operationId: createContractDefinitionV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: contract definition was created successfully. Returns the Contract Definition Id and created timestamp
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request body was malformed
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Could not create contract definition, because a contract definition with that ID already exists
+      tags:
+        - Contract Definition V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractdefinitions
+    put:
+      description: Updated a contract definition with the given ID. The supplied JSON structure must be a valid JSON-LD object
+      operationId: updateContractDefinitionV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "204":
+          description: Contract definition was updated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: A contract definition with the given ID does not exist
+      tags:
+        - Contract Definition V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: PUT
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractdefinitions
+  /v3/policydefinitions/request:
+    post:
+      description: Returns all policy definitions according to a query
+      operationId: queryPolicyDefinitionsV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: The policy definitions matching the query
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed
+      tags:
+        - Policy Definition V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/policydefinitions/request
   /v3/secrets/{id}:
     delete:
       description: Removes a secret with the given ID if possible.
@@ -1408,15 +682,15 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: A secret with the given ID does not exist
       tags:
         - Secret V3
@@ -1425,11 +699,11 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: DELETE
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         requestParameters:
           integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/secrets/{id}
+        uri: http://${loadBalancerDnsName}/api/management/v3/secrets/{id}
     get:
       description: Gets a secret with the given ID
       operationId: getSecretV3
@@ -1444,7 +718,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SecretOutput"
+                type: object
           description: The secret
         "400":
           content:
@@ -1452,15 +726,15 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: A secret with the given ID does not exist
       tags:
         - Secret V3
@@ -1469,46 +743,450 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: GET
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         requestParameters:
           integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/secrets/{id}
-  /v3/transferprocesses:
+        uri: http://${loadBalancerDnsName}/api/management/v3/secrets/{id}
+  /{flowId}/{resourceId}/deprovision:
     post:
-      description:
-        "Initiates a data transfer with the given parameters. Due to the\
-        \ asynchronous nature of transfers, a successful response only indicates that\
-        \ the request was successfully received. This may take a long time, so clients\
-        \ must poll the /{id}/state endpoint to track the state."
-      operationId: initiateTransferProcessV3
+      operationId: deprovision
+      parameters:
+        - name: flowId
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        default:
+          description: default response
+          content:
+            "*/*": {}
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/{flowId}/{resourceId}/deprovision
+        requestParameters:
+          integration.request.path.flowId: method.request.path.flowId
+          integration.request.path.resourceId: method.request.path.resourceId
+  /v3/assets:
+    post:
+      description: Creates a new asset together with a data address
+      operationId: createAssetV3
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TransferRequest"
+              type: object
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IdResponse"
-          description:
-            The transfer was successfully initiated. Returns the transfer
-            process ID and created timestamp
-          links:
-            poll-state:
-              operationId: getTransferProcessStateV3
-              parameters:
-                id: $response.body#/id
+                type: object
+          description: Asset was created successfully. Returns the asset Id and created timestamp
         "400":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: Request body was malformed
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Could not create asset, because an asset with that ID already exists
+      tags:
+        - Asset V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/assets
+    put:
+      description:
+        "Updates an asset with the given ID if it exists. If the asset is not found, no further action is taken.
+        DANGER ZONE: Note that updating assets can have unexpected results, especially for contract offers that have been
+        sent out or are ongoing in contract negotiations."
+      operationId: updateAssetV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "204":
+          description: Asset was updated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          description: Asset could not be updated, because it does not exist.
+      tags:
+        - Asset V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: PUT
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/assets
+  /v3/transferprocesses/{id}/state:
+    get:
+      description: Gets the state of a transfer process with the given ID
+      operationId: getTransferProcessStateV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: The  transfer process's state
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: An  transfer process with the given ID does not exist
+      tags:
+        - Transfer Process V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: GET
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/transferprocesses/{id}/state
+  /v3/contractagreements/request:
+    post:
+      description: Gets all contract agreements according to a particular query
+      operationId: queryAgreementsV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: The contract agreements matching the query
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request body was malformed
+      tags:
+        - Contract Agreement V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractagreements/request
+  /v3/policydefinitions/{id}:
+    delete:
+      description:
+        "Removes a policy definition with the given ID if possible. Deleting a policy definition is only possible
+        if that policy definition is not yet referenced by a contract definition, in which case an error is returned. DANGER
+        ZONE: Note that deleting policy definitions can have unexpected results, do this at your own risk!"
+      operationId: deletePolicyDefinitionV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Policy definition was deleted successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: An policy definition with the given ID does not exist
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: The policy definition cannot be deleted, because it is referenced by a contract definition
+      tags:
+        - Policy Definition V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: DELETE
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/policydefinitions/{id}
+    get:
+      description: Gets a policy definition with the given ID
+      operationId: getPolicyDefinitionV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: The  policy definition
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: An  policy definition with the given ID does not exist
+      tags:
+        - Policy Definition V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: GET
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/policydefinitions/{id}
+    put:
+      description: Updates an existing Policy, If the Policy is not found, an error is reported
+      operationId: updatePolicyDefinitionV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "204":
+          description: policy definition was updated successfully.
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request body was malformed
+        "404":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: policy definition could not be updated, because it does not exists
+      tags:
+        - Policy Definition V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: PUT
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/policydefinitions/{id}
+  /v3/edrs/request:
+    post:
+      tags:
+        - EDR Cache V3
+      description: Request all Edr entries according to a particular query
+      operationId: requestEdrEntriesV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: The edr entries matching the query
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/edrs/request
+  /v3/catalog/request:
+    post:
+      operationId: requestCatalogV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Gets contract offers (=catalog) of a single connector
+      tags:
+        - Catalog V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/catalog/request
+  /v3/transferprocesses/{id}/terminate:
+    post:
+      description:
+        Requests the termination of a transfer process. Due to the asynchronous nature of transfers, a successful
+        response only indicates that the request was successfully received. This may take a long time, so clients must poll
+        the /{id}/state endpoint to track the state.
+      operationId: terminateTransferProcessV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "204":
+          description: Request to terminate the transfer process was successfully received
+          links:
+            poll-state:
+              operationId: terminateTransferProcessV3
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: A transfer process with the given ID does not exist
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Could not terminate transfer process, because it is already completed or terminated.
       tags:
         - Transfer Process V3
       x-amazon-apigateway-auth:
@@ -1516,9 +1194,236 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/transferprocesses
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/transferprocesses/{id}/terminate
+  /v3/policydefinitions/{id}/evaluationplan:
+    post:
+      tags:
+        - Policy Definition v3
+      description: Creates an execution plane for an existing Policy, If the Policy is not found, an error is reported
+      operationId: createExecutionPlaneV3
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Returns the evaluation plan
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: An evaluation plan could not be created, because the policy definition does not exists
+          content:
+            application/json:
+              schema:
+                type: object
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/policydefinitions/{id}/evaluationplan
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /v3/contractnegotiations/{id}/terminate:
+    post:
+      description: Terminates the contract negotiation.
+      operationId: terminateNegotiationV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: ContractNegotiation is terminating
+          links:
+            poll-state:
+              operationId: getNegotiationStateV3
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: A contract negotiation with the given ID does not exist
+      tags:
+        - Contract Negotiation V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractnegotiations/{id}/terminate
+  /v3/transferprocesses/{id}/deprovision:
+    post:
+      description:
+        Requests the deprovisioning of resources associated with a transfer process. Due to the asynchronous nature
+        of transfers, a successful response only indicates that the request was successfully received. This may take a long
+        time, so clients must poll the /{id}/state endpoint to track the state.
+      operationId: deprovisionTransferProcessV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Request to deprovision the transfer process was successfully received
+          links:
+            poll-state:
+              operationId: deprovisionTransferProcessV3
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: A transfer process with the given ID does not exist
+      tags:
+        - Transfer Process V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/transferprocesses/{id}/deprovision
+  /v3/dataplanes:
+    get:
+      description: Returns a list of all currently registered data plane instances
+      operationId: getAllDataPlaneInstancesV3
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: A (potentially empty) list of currently registered data plane instances
+      tags:
+        - Dataplane Selector V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: GET
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/dataplanes
+  /{flowId}/{resourceId}/provision:
+    post:
+      operationId: provision
+      parameters:
+        - name: flowId
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          "*/*":
+            schema:
+              type: object
+      responses:
+        default:
+          description: default response
+          content:
+            "*/*": {}
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/{flowId}/{resourceId}/provision
+        requestParameters:
+          integration.request.path.flowId: method.request.path.flowId
+          integration.request.path.resourceId: method.request.path.resourceId
+  /v3/catalog/dataset/request:
+    post:
+      operationId: getDatasetV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Gets single dataset from a connector
+      tags:
+        - Catalog V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/catalog/dataset/request
   /v3/transferprocesses/request:
     post:
       description: Returns all transfer process according to a query
@@ -1527,7 +1432,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/QuerySpec"
+              type: object
       responses:
         "200":
           content:
@@ -1535,7 +1440,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/TransferProcess"
+                  type: object
           description: The transfer processes matching the query
         "400":
           content:
@@ -1543,7 +1448,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: Request was malformed
       tags:
         - Transfer Process V3
@@ -1552,9 +1457,9 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
-        uri: http://${loadBalancerDnsName}/management/v3/transferprocesses/request
+        uri: http://${loadBalancerDnsName}/api/management/v3/transferprocesses/request
   /v3/transferprocesses/{id}:
     get:
       description: Gets an transfer process with the given ID
@@ -1570,7 +1475,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TransferProcess"
+                type: object
           description: The transfer process
         "400":
           content:
@@ -1578,15 +1483,15 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: A transfer process with the given ID does not exist
       tags:
         - Transfer Process V3
@@ -1595,20 +1500,18 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: GET
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         requestParameters:
           integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/transferprocesses/{id}
-  /v3/transferprocesses/{id}/deprovision:
-    post:
+        uri: http://${loadBalancerDnsName}/api/management/v3/transferprocesses/{id}
+  /v3/contractdefinitions/{id}:
+    delete:
       description:
-        "Requests the deprovisioning of resources associated with a transfer\
-        \ process. Due to the asynchronous nature of transfers, a successful response\
-        \ only indicates that the request was successfully received. This may take\
-        \ a long time, so clients must poll the /{id}/state endpoint to track the\
-        \ state."
-      operationId: deprovisionTransferProcessV3
+        "Removes a contract definition with the given ID if possible. DANGER ZONE: Note that deleting contract
+        definitions can have unexpected results, especially for contract offers that have been sent out or ongoing or contract
+        negotiations."
+      operationId: deleteContractDefinitionV3
       parameters:
         - in: path
           name: id
@@ -1617,47 +1520,128 @@ paths:
             type: string
       responses:
         "204":
-          description:
-            Request to deprovision the transfer process was successfully
-            received
-          links:
-            poll-state:
-              operationId: deprovisionTransferProcessV3
+          description: Contract definition was deleted successfully
         "400":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: A transfer process with the given ID does not exist
+                  type: object
+          description: A contract definition with the given ID does not exist
       tags:
-        - Transfer Process V3
+        - Contract Definition V3
       x-amazon-apigateway-auth:
         type: AWS_IAM
       x-amazon-apigateway-integration:
         type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        httpMethod: DELETE
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         requestParameters:
           integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/transferprocesses/{id}/deprovision
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractdefinitions/{id}
+    get:
+      description: Gets an contract definition with the given ID
+      operationId: getContractDefinitionV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: The contract definition
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: An contract agreement with the given ID does not exist
+      tags:
+        - Contract Definition V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: GET
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractdefinitions/{id}
+  /v3/edrs/{transferProcessId}:
+    delete:
+      tags:
+        - EDR Cache V3
+      description: Removes an EDR entry given the transfer process ID
+      operationId: removeEdrEntryV3
+      parameters:
+        - name: transferProcessId
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "204":
+          description: EDR entry was deleted successfully
+        "400":
+          description: Request was malformed, e.g. id was null
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        "404":
+          description: An EDR entry with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/edrs/{transferProcessId}
+        requestParameters:
+          integration.request.path.transferProcessId: method.request.path.transferProcessId
   /v3/transferprocesses/{id}/resume:
     post:
       description:
-        "Requests the resumption of a suspended transfer process. Due to\
-        \ the asynchronous nature of transfers, a successful response only indicates\
-        \ that the request was successfully received. This may take a long time, so\
-        \ clients must poll the /{id}/state endpoint to track the state."
+        Requests the resumption of a suspended transfer process. Due to the asynchronous nature of transfers, a
+        successful response only indicates that the request was successfully received. This may take a long time, so clients
+        must poll the /{id}/state endpoint to track the state.
       operationId: resumeTransferProcessV3
       parameters:
         - in: path
@@ -1677,15 +1661,15 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
+                  type: object
           description: A transfer process with the given ID does not exist
       tags:
         - Transfer Process V3
@@ -1694,15 +1678,57 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         requestParameters:
           integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/transferprocesses/{id}/resume
-  /v3/transferprocesses/{id}/state:
+        uri: http://${loadBalancerDnsName}/api/management/v3/transferprocesses/{id}/resume
+  /v3/policydefinitions:
+    post:
+      description: Creates a new policy definition
+      operationId: createPolicyDefinitionV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: policy definition was created successfully. Returns the Policy Definition Id and created timestamp
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request body was malformed
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Could not create policy definition, because a contract definition with that ID already exists
+      tags:
+        - Policy Definition V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/policydefinitions
+  /v3/contractagreements/{id}/negotiation:
     get:
-      description: Gets the state of a transfer process with the given ID
-      operationId: getTransferProcessStateV3
+      description: Gets a contract negotiation with the given contract agreement ID
+      operationId: getNegotiationByAgreementIdV3
       parameters:
         - in: path
           name: id
@@ -1714,47 +1740,79 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TransferState"
-          description: The  transfer process's state
+                type: object
+          description: The contract negotiation
         "400":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: An  transfer process with the given ID does not exist
+                  type: object
+          description: An contract agreement with the given ID does not exist
       tags:
-        - Transfer Process V3
+        - Contract Agreement V3
       x-amazon-apigateway-auth:
         type: AWS_IAM
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: GET
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         requestParameters:
           integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/transferprocesses/{id}/state
-  /v3/transferprocesses/{id}/suspend:
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractagreements/{id}/negotiation
+  /v3/policydefinitions/{id}/validate:
     post:
-      description:
-        "Requests the suspension of a transfer process. Due to the asynchronous\
-        \ nature of transfers, a successful response only indicates that the request\
-        \ was successfully received. This may take a long time, so clients must poll\
-        \ the /{id}/state endpoint to track the state."
-      operationId: suspendTransferProcessV3
+      tags:
+        - Policy Definition v3
+      description: Validates an existing Policy, If the Policy is not found, an error is reported
+      operationId: validatePolicyDefinitionV3
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Returns the validation result
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: policy definition could not be validated, because it does not exists
+          content:
+            application/json:
+              schema:
+                type: object
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: ANY
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/policydefinitions/{id}/validate
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+  /callback/{processId}/deprovision:
+    post:
+      operationId: callDeprovisionWebhook
       parameters:
         - in: path
-          name: id
+          name: processId
           required: true
           schema:
             type: string
@@ -1762,39 +1820,54 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SuspendTransfer"
+              type: object
       responses:
-        "204":
-          description: Request to suspend the transfer process was successfully received
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+        - HTTP Provisioner Webhook
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/callback/{processId}/deprovision
+  /v3/transferprocesses:
+    post:
+      description:
+        Initiates a data transfer with the given parameters. Due to the asynchronous nature of transfers, a successful
+        response only indicates that the request was successfully received. This may take a long time, so clients must poll
+        the /{id}/state endpoint to track the state.
+      operationId: initiateTransferProcessV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: The transfer was successfully initiated. Returns the transfer process ID and created timestamp
           links:
             poll-state:
-              operationId: suspendTransferProcessV3
+              operationId: getTransferProcessStateV3
+              parameters:
+                id: $response.body#/id
         "400":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: A transfer process with the given ID does not exist
-        "409":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description:
-            "Could not suspend the transfer process, because it is already\
-            \ completed or terminated."
+                  type: object
+          description: Request body was malformed
       tags:
         - Transfer Process V3
       x-amazon-apigateway-auth:
@@ -1802,1030 +1875,96 @@ paths:
       x-amazon-apigateway-integration:
         type: http_proxy
         httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
-        requestParameters:
-          integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/transferprocesses/{id}/suspend
-  /v3/transferprocesses/{id}/terminate:
-    post:
-      description:
-        "Requests the termination of a transfer process. Due to the asynchronous\
-        \ nature of transfers, a successful response only indicates that the request\
-        \ was successfully received. This may take a long time, so clients must poll\
-        \ the /{id}/state endpoint to track the state."
-      operationId: terminateTransferProcessV3
+        uri: http://${loadBalancerDnsName}/api/management/v3/transferprocesses
+  /v3/contractnegotiations/{id}:
+    get:
+      description: Gets a contract negotiation with the given ID
+      operationId: getNegotiationV3
       parameters:
         - in: path
           name: id
           required: true
           schema:
             type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TerminateTransfer"
       responses:
-        "204":
-          description:
-            Request to terminate the transfer process was successfully
-            received
-          links:
-            poll-state:
-              operationId: terminateTransferProcessV3
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: The contract negotiation
         "400":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: "Request was malformed, e.g. id was null"
+                  type: object
+          description: Request was malformed, e.g. id was null
         "404":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description: A transfer process with the given ID does not exist
-        "409":
+                  type: object
+          description: An contract negotiation with the given ID does not exist
+      tags:
+        - Contract Negotiation V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: GET
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractnegotiations/{id}
+  /v3/contractnegotiations/{id}/state:
+    get:
+      description: Gets the state of a contract negotiation with the given ID
+      operationId: getNegotiationStateV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: The contract negotiation's state
+        "400":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ApiErrorDetail"
-          description:
-            "Could not terminate transfer process, because it is already\
-            \ completed or terminated."
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: An contract negotiation with the given ID does not exist
       tags:
-        - Transfer Process V3
+        - Contract Negotiation V3
       x-amazon-apigateway-auth:
         type: AWS_IAM
       x-amazon-apigateway-integration:
         type: http_proxy
-        httpMethod: POST
-        connectionId: "${vpcLinkId}"
+        httpMethod: GET
+        connectionId: ${vpcLinkId}
         connectionType: VPC_LINK
         requestParameters:
           integration.request.path.id: method.request.path.id
-        uri: http://${loadBalancerDnsName}/management/v3/transferprocesses/{id}/terminate
-components:
-  schemas:
-    ApiErrorDetail:
-      type: object
-      example:
-        message: error message
-        type: ErrorType
-        path: object.error.path
-        invalidValue: this value is not valid
-      properties:
-        invalidValue:
-          type: string
-        message:
-          type: string
-        path:
-          type: string
-        type:
-          type: string
-    AssetInput:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": asset-id
-        properties:
-          key: value
-        privateProperties:
-          privateKey: privateValue
-        dataAddress:
-          type: HttpData
-          baseUrl: https://jsonplaceholder.typicode.com/todos
-      properties:
-        "@context":
-          type: object
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/Asset
-        dataAddress:
-          $ref: "#/components/schemas/DataAddress"
-        privateProperties:
-          $ref: "#/components/schemas/Properties"
-        properties:
-          $ref: "#/components/schemas/Properties"
-      required:
-        - "@context"
-        - dataAddress
-        - properties
-    AssetOutput:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": asset-id
-        properties:
-          key: value
-        privateProperties:
-          privateKey: privateValue
-        dataAddress:
-          type: HttpData
-          baseUrl: https://jsonplaceholder.typicode.com/todos
-        createdAt: 1688465655
-      properties:
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/Asset
-        createdAt:
-          type: integer
-          format: int64
-        dataAddress:
-          $ref: "#/components/schemas/DataAddress"
-        privateProperties:
-          $ref: "#/components/schemas/Properties"
-        properties:
-          $ref: "#/components/schemas/Properties"
-    CallbackAddress:
-      type: object
-      properties:
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/CallbackAddress
-        authCodeId:
-          type: string
-        authKey:
-          type: string
-        events:
-          type: array
-          items:
-            type: string
-          uniqueItems: true
-        transactional:
-          type: boolean
-        uri:
-          type: string
-    Catalog:
-      type: object
-      description: DCAT catalog
-      example:
-        "@id": 7df65569-8c59-4013-b1c0-fa14f6641bf2
-        "@type": dcat:Catalog
-        dcat:dataset:
-          "@id": bcca61be-e82e-4da6-bfec-9716a56cef35
-          "@type": dcat:Dataset
-          odrl:hasPolicy:
-            "@id": OGU0ZTMzMGMtODQ2ZS00ZWMxLThmOGQtNWQxNWM0NmI2NmY4:YmNjYTYxYmUtZTgyZS00ZGE2LWJmZWMtOTcxNmE1NmNlZjM1:NDY2ZTZhMmEtNjQ1Yy00ZGQ0LWFlZDktMjdjNGJkZTU4MDNj
-            "@type": odrl:Set
-            odrl:permission:
-              odrl:target: bcca61be-e82e-4da6-bfec-9716a56cef35
-              odrl:action:
-                odrl:type: http://www.w3.org/ns/odrl/2/use
-              odrl:constraint:
-                odrl:and:
-                  - odrl:leftOperand: https://w3id.org/edc/v0.0.1/ns/inForceDate
-                    odrl:operator:
-                      "@id": odrl:gteq
-                    odrl:rightOperand: 2023-07-07T07:19:58.585601395Z
-                  - odrl:leftOperand: https://w3id.org/edc/v0.0.1/ns/inForceDate
-                    odrl:operator:
-                      "@id": odrl:lteq
-                    odrl:rightOperand: 2023-07-12T07:19:58.585601395Z
-            odrl:prohibition: []
-            odrl:obligation: []
-          dcat:distribution:
-            - "@type": dcat:Distribution
-              dct:format:
-                "@id": HttpData
-              dcat:accessService: 5e839777-d93e-4785-8972-1005f51cf367
-          description: description
-          id: bcca61be-e82e-4da6-bfec-9716a56cef35
-        dcat:service:
-          "@id": 5e839777-d93e-4785-8972-1005f51cf367
-          "@type": dcat:DataService
-          dct:terms: connector
-          dct:endpointUrl: http://localhost:16806/protocol
-        dspace:participantId: urn:connector:provider
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-          dct: http://purl.org/dc/terms/
-          edc: https://w3id.org/edc/v0.0.1/ns/
-          dcat: http://www.w3.org/ns/dcat#
-          odrl: http://www.w3.org/ns/odrl/2/
-          dspace: https://w3id.org/dspace/v0.8/
-    CatalogRequest:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": CatalogRequest
-        counterPartyAddress: http://provider-address
-        counterPartyId: providerId
-        protocol: dataspace-protocol-http
-        querySpec:
-          offset: 0
-          limit: 50
-          sortOrder: DESC
-          sortField: fieldName
-          filterExpression: []
-      properties:
-        "@context":
-          type: object
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/CatalogRequest
-        counterPartyAddress:
-          type: string
-        counterPartyId:
-          type: string
-        protocol:
-          type: string
-        querySpec:
-          $ref: "#/components/schemas/QuerySpec"
-      required:
-        - "@context"
-        - counterPartyAddress
-        - protocol
-    ContractAgreement:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": https://w3id.org/edc/v0.0.1/ns/ContractAgreement
-        "@id": negotiation-id
-        providerId: provider-id
-        consumerId: consumer-id
-        assetId: asset-id
-        contractSigningDate: 1688465655
-        policy:
-          "@context": http://www.w3.org/ns/odrl.jsonld
-          "@type": Set
-          "@id": offer-id
-          permission:
-            - target: asset-id
-              action: display
-      properties:
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/ContractAgreement
-        assetId:
-          type: string
-        consumerId:
-          type: string
-        contractSigningDate:
-          type: integer
-          format: int64
-        policy:
-          $ref: "#/components/schemas/Policy"
-        providerId:
-          type: string
-    ContractDefinitionInput:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": definition-id
-        accessPolicyId: asset-policy-id
-        contractPolicyId: contract-policy-id
-        assetsSelector: []
-      properties:
-        "@context":
-          type: object
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/ContractDefinition
-        accessPolicyId:
-          type: string
-        assetsSelector:
-          type: array
-          items:
-            $ref: "#/components/schemas/Criterion"
-        contractPolicyId:
-          type: string
-      required:
-        - "@context"
-        - accessPolicyId
-        - assetsSelector
-        - contractPolicyId
-    ContractDefinitionOutput:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": definition-id
-        accessPolicyId: asset-policy-id
-        contractPolicyId: contract-policy-id
-        assetsSelector: []
-        createdAt: 1688465655
-      properties:
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/ContractDefinition
-        accessPolicyId:
-          type: string
-        assetsSelector:
-          type: array
-          items:
-            $ref: "#/components/schemas/Criterion"
-        contractPolicyId:
-          type: string
-        createdAt:
-          type: integer
-          format: int64
-    ContractNegotiation:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": https://w3id.org/edc/v0.0.1/ns/ContractNegotiation
-        "@id": negotiation-id
-        type: PROVIDER
-        protocol: dataspace-protocol-http
-        counterPartyId: counter-party-id
-        counterPartyAddress: http://counter/party/address
-        state: VERIFIED
-        contractAgreementId: contract:agreement:id
-        errorDetail: eventual-error-detail
-        createdAt: 1688465655
-        callbackAddresses:
-          - transactional: false
-            uri: http://callback/url
-            events:
-              - contract.negotiation
-              - transfer.process
-            authKey: auth-key
-            authCodeId: auth-code-id
-      properties:
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/ContractNegotiation
-        callbackAddresses:
-          type: array
-          items:
-            $ref: "#/components/schemas/CallbackAddress"
-        contractAgreementId:
-          type: string
-        counterPartyAddress:
-          type: string
-        counterPartyId:
-          type: string
-        errorDetail:
-          type: string
-        protocol:
-          type: string
-        state:
-          type: string
-        type:
-          type: string
-          enum:
-            - CONSUMER
-            - PROVIDER
-    ContractRequest:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": https://w3id.org/edc/v0.0.1/ns/ContractRequest
-        counterPartyAddress: http://provider-address
-        protocol: dataspace-protocol-http
-        policy:
-          "@context": http://www.w3.org/ns/odrl.jsonld
-          "@type": odrl:Offer
-          "@id": offer-id
-          assigner: providerId
-          permission: []
-          prohibition: []
-          obligation: []
-          target: assetId
-        callbackAddresses:
-          - transactional: false
-            uri: http://callback/url
-            events:
-              - contract.negotiation
-              - transfer.process
-            authKey: auth-key
-            authCodeId: auth-code-id
-      properties:
-        "@context":
-          type: object
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/ContractRequest
-        callbackAddresses:
-          type: array
-          items:
-            $ref: "#/components/schemas/CallbackAddress"
-        counterPartyAddress:
-          type: string
-        policy:
-          $ref: "#/components/schemas/Offer"
-        protocol:
-          type: string
-      required:
-        - "@context"
-        - counterPartyAddress
-        - policy
-        - protocol
-    Criterion:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": Criterion
-        operandLeft: fieldName
-        operator: =
-        operandRight: some value
-      properties:
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/Criterion
-        operandLeft:
-          type: object
-        operandRight:
-          type: object
-        operator:
-          type: string
-      required:
-        - operandLeft
-        - operandRight
-        - operator
-    DataAddress:
-      type: object
-      properties:
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/DataAddress
-        type:
-          type: string
-    DataPlaneInstanceSchema:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": your-dataplane-id
-        url: http://somewhere.com:1234/api/v1
-        allowedSourceTypes:
-          - source-type1
-          - source-type2
-        allowedDestTypes:
-          - your-dest-type
-        allowedTransferTypes:
-          - transfer-type
-      properties:
-        "@context":
-          type: object
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/DataPlaneInstance
-        allowedDestTypes:
-          type: array
-          items:
-            type: string
-          uniqueItems: true
-        allowedSourceTypes:
-          type: array
-          items:
-            type: string
-          uniqueItems: true
-        lastActive:
-          type: integer
-          format: int64
-        turnCount:
-          type: integer
-          format: int32
-        url:
-          type: string
-          format: url
-      required:
-        - "@context"
-        - allowedDestTypes
-        - allowedSourceTypes
-        - url
-    Dataset:
-      type: object
-      description: DCAT dataset
-      example:
-        "@id": bcca61be-e82e-4da6-bfec-9716a56cef35
-        "@type": dcat:Dataset
-        odrl:hasPolicy:
-          "@id": OGU0ZTMzMGMtODQ2ZS00ZWMxLThmOGQtNWQxNWM0NmI2NmY4:YmNjYTYxYmUtZTgyZS00ZGE2LWJmZWMtOTcxNmE1NmNlZjM1:NDY2ZTZhMmEtNjQ1Yy00ZGQ0LWFlZDktMjdjNGJkZTU4MDNj
-          "@type": odrl:Set
-          odrl:permission:
-            odrl:target: bcca61be-e82e-4da6-bfec-9716a56cef35
-            odrl:action:
-              odrl:type: http://www.w3.org/ns/odrl/2/use
-            odrl:constraint:
-              odrl:and:
-                - odrl:leftOperand: https://w3id.org/edc/v0.0.1/ns/inForceDate
-                  odrl:operator:
-                    "@id": odrl:gteq
-                  odrl:rightOperand: 2023-07-07T07:19:58.585601395Z
-                - odrl:leftOperand: https://w3id.org/edc/v0.0.1/ns/inForceDate
-                  odrl:operator:
-                    "@id": odrl:lteq
-                  odrl:rightOperand: 2023-07-12T07:19:58.585601395Z
-          odrl:prohibition: []
-          odrl:obligation: []
-          odrl:target: bcca61be-e82e-4da6-bfec-9716a56cef35
-        dcat:distribution:
-          - "@type": dcat:Distribution
-            dct:format:
-              "@id": HttpData
-            dcat:accessService: 5e839777-d93e-4785-8972-1005f51cf367
-        description: description
-        id: bcca61be-e82e-4da6-bfec-9716a56cef35
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-          dct: http://purl.org/dc/terms/
-          edc: https://w3id.org/edc/v0.0.1/ns/
-          dcat: http://www.w3.org/ns/dcat#
-          odrl: http://www.w3.org/ns/odrl/2/
-          dspace: https://w3id.org/dspace/v0.8/
-    DatasetRequest:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": DatasetRequest
-        "@id": dataset-id
-        counterPartyAddress: http://counter-party-address
-        counterPartyId: counter-party-id
-        protocol: dataspace-protocol-http
-      properties:
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/CatalogRequest
-        counterPartyAddress:
-          type: string
-        counterPartyId:
-          type: string
-        protocol:
-          type: string
-        querySpec:
-          $ref: "#/components/schemas/QuerySpec"
-    DeprovisionedResource:
-      type: object
-      properties:
-        error:
-          type: boolean
-        errorMessage:
-          type: string
-        inProcess:
-          type: boolean
-        provisionedResourceId:
-          type: string
-    EndpointDataReferenceEntry:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": transfer-process-id
-        transferProcessId: transfer-process-id
-        agreementId: agreement-id
-        contractNegotiationId: contract-negotiation-id
-        assetId: asset-id
-        providerId: provider-id
-        createdAt: 1688465655
-      properties:
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/EndpointDataReferenceEntry
-    IdResponse:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": id-value
-        createdAt: 1688465655
-      properties:
-        "@id":
-          type: string
-        createdAt:
-          type: integer
-          format: int64
-    JsonArray:
-      type: array
-      items:
-        $ref: "#/components/schemas/JsonValue"
-      properties:
-        empty:
-          type: boolean
-        first:
-          $ref: "#/components/schemas/JsonValue"
-        last:
-          $ref: "#/components/schemas/JsonValue"
-        valueType:
-          type: string
-          enum:
-            - ARRAY
-            - OBJECT
-            - STRING
-            - NUMBER
-            - "TRUE"
-            - "FALSE"
-            - "NULL"
-    JsonObject:
-      type: object
-      additionalProperties:
-        $ref: "#/components/schemas/JsonValue"
-      properties:
-        empty:
-          type: boolean
-        valueType:
-          type: string
-          enum:
-            - ARRAY
-            - OBJECT
-            - STRING
-            - NUMBER
-            - "TRUE"
-            - "FALSE"
-            - "NULL"
-    JsonValue:
-      type: object
-      properties:
-        valueType:
-          type: string
-          enum:
-            - ARRAY
-            - OBJECT
-            - STRING
-            - NUMBER
-            - "TRUE"
-            - "FALSE"
-            - "NULL"
-    NegotiationState:
-      type: object
-      properties:
-        state:
-          type: string
-    Offer:
-      type: object
-      description: ODRL offer
-      example:
-        "@context": http://www.w3.org/ns/odrl.jsonld
-        "@type": odrl:Offer
-        "@id": offer-id
-        assigner: providerId
-        target: assetId
-        permission: []
-        prohibition: []
-        obligation: []
-      properties:
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: http://www.w3.org/ns/odrl/2/Offer
-        assigner:
-          type: string
-        target:
-          type: string
-      required:
-        - "@id"
-        - assigner
-        - target
-    Policy:
-      type: object
-      description: ODRL policy
-      example:
-        "@context": http://www.w3.org/ns/odrl.jsonld
-        "@id": 0949ba30-680c-44e6-bc7d-1688cbe1847e
-        "@type": odrl:Set
-        permission:
-          target: http://example.com/asset:9898.movie
-          action:
-            type: http://www.w3.org/ns/odrl/2/use
-          constraint:
-            leftOperand: https://w3id.org/edc/v0.0.1/ns/left
-            operator: eq
-            rightOperand: value
-        prohibition: []
-        obligation: []
-    PolicyDefinitionInput:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": definition-id
-        policy:
-          "@context": http://www.w3.org/ns/odrl.jsonld
-          "@type": Set
-          uid: http://example.com/policy:1010
-          permission:
-            - target: http://example.com/asset:9898.movie
-              action: display
-              constraint:
-                - leftOperand: spatial
-                  operator: eq
-                  rightOperand: https://www.wikidata.org/wiki/Q183
-                  comment: i.e Germany
-      properties:
-        "@context":
-          type: object
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/PolicyDefinition
-        policy:
-          $ref: "#/components/schemas/Policy"
-      required:
-        - "@context"
-        - policy
-    PolicyDefinitionOutput:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": definition-id
-        policy:
-          "@context": http://www.w3.org/ns/odrl.jsonld
-          "@type": Set
-          uid: http://example.com/policy:1010
-          permission:
-            - target: http://example.com/asset:9898.movie
-              action: display
-              constraint:
-                - leftOperand: spatial
-                  operator: eq
-                  rightOperand: https://www.wikidata.org/wiki/Q183
-                  comment: i.e Germany
-        createdAt: 1688465655
-      properties:
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/PolicyDefinition
-        policy:
-          $ref: "#/components/schemas/Policy"
-    Properties:
-      type: object
-    ProvisionerWebhookRequest:
-      type: object
-      properties:
-        apiKeyJwt:
-          type: string
-        assetId:
-          type: string
-        contentDataAddress:
-          $ref: "#/components/schemas/DataAddress"
-        hasToken:
-          type: boolean
-        resourceDefinitionId:
-          type: string
-        resourceName:
-          type: string
-    QuerySpec:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": QuerySpec
-        offset: 5
-        limit: 10
-        sortOrder: DESC
-        sortField: fieldName
-        filterExpression: []
-      properties:
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/QuerySpec
-        filterExpression:
-          type: array
-          items:
-            $ref: "#/components/schemas/Criterion"
-        limit:
-          type: integer
-          format: int32
-        offset:
-          type: integer
-          format: int32
-        sortField:
-          type: string
-        sortOrder:
-          type: string
-          enum:
-            - ASC
-            - DESC
-    SecretInput:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": secret-id
-        value: secret-value
-      properties:
-        "@context":
-          type: object
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/Secret
-        value:
-          type: string
-      required:
-        - "@context"
-        - value
-    SecretOutput:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@id": secret-id
-        "@type": https://w3id.org/edc/v0.0.1/ns/Secret
-        value: secret-value
-      properties:
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/Secret
-        value:
-          type: string
-      required:
-        - value
-    SuspendTransfer:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": https://w3id.org/edc/v0.0.1/ns/SuspendTransfer
-        reason: a reason to suspend
-      properties:
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/SuspendTransfer
-        state:
-          type: string
-    TerminateNegotiationSchema:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": https://w3id.org/edc/v0.0.1/ns/TerminateNegotiation
-        "@id": negotiation-id
-        reason: a reason to terminate
-      properties:
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/TerminateNegotiation
-        reason:
-          type: string
-    TerminateTransfer:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": https://w3id.org/edc/v0.0.1/ns/TerminateTransfer
-        reason: a reason to terminate
-      properties:
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/TerminateTransfer
-        state:
-          type: string
-    TransferProcess:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": https://w3id.org/edc/v0.0.1/ns/TransferProcess
-        "@id": process-id
-        correlationId: correlation-id
-        type: PROVIDER
-        state: STARTED
-        stateTimestamp: 1688465655
-        assetId: asset-id
-        contractId: contractId
-        dataDestination:
-          type: data-destination-type
-        privateProperties:
-          private-key: private-value
-        errorDetail: eventual-error-detail
-        createdAt: 1688465655
-        callbackAddresses:
-          - transactional: false
-            uri: http://callback/url
-            events:
-              - contract.negotiation
-              - transfer.process
-            authKey: auth-key
-            authCodeId: auth-code-id
-      properties:
-        "@id":
-          type: string
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/TransferProcess
-        callbackAddresses:
-          type: array
-          items:
-            $ref: "#/components/schemas/CallbackAddress"
-        contractAgreementId:
-          type: string
-        counterPartyAddress:
-          type: string
-        counterPartyId:
-          type: string
-        dataDestination:
-          $ref: "#/components/schemas/DataAddress"
-        errorDetail:
-          type: string
-        privateProperties:
-          $ref: "#/components/schemas/Properties"
-        protocol:
-          type: string
-        state:
-          type: string
-        type:
-          type: string
-          enum:
-            - CONSUMER
-            - PROVIDER
-    TransferRequest:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": https://w3id.org/edc/v0.0.1/ns/TransferRequest
-        protocol: dataspace-protocol-http
-        counterPartyAddress: http://provider-address
-        contractId: contract-id
-        transferType: transferType
-        dataDestination:
-          type: data-destination-type
-        privateProperties:
-          private-key: private-value
-        callbackAddresses:
-          - transactional: false
-            uri: http://callback/url
-            events:
-              - contract.negotiation
-              - transfer.process
-            authKey: auth-key
-            authCodeId: auth-code-id
-      properties:
-        "@context":
-          type: object
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/TransferRequest
-        assetId:
-          type: string
-          deprecated: true
-        callbackAddresses:
-          type: array
-          items:
-            $ref: "#/components/schemas/CallbackAddress"
-        contractId:
-          type: string
-        counterPartyAddress:
-          type: string
-        dataDestination:
-          $ref: "#/components/schemas/DataAddress"
-        privateProperties:
-          $ref: "#/components/schemas/Properties"
-        protocol:
-          type: string
-        transferType:
-          type: string
-      required:
-        - "@context"
-        - contractId
-        - counterPartyAddress
-        - protocol
-        - transferType
-    TransferState:
-      type: object
-      example:
-        "@context":
-          "@vocab": https://w3id.org/edc/v0.0.1/ns/
-        "@type": https://w3id.org/edc/v0.0.1/ns/TransferState
-        state: STARTED
-      properties:
-        "@type":
-          type: string
-          example: https://w3id.org/edc/v0.0.1/ns/TransferState
-        state:
-          type: string
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractnegotiations/{id}/state

--- a/cdk/api/management-api.yaml
+++ b/cdk/api/management-api.yaml
@@ -1078,6 +1078,40 @@ paths:
         requestParameters:
           integration.request.path.id: method.request.path.id
         uri: http://${loadBalancerDnsName}/api/management/v3/policydefinitions/{id}
+  /v3/edrs:
+    post:
+      tags:
+        - EDR Cache V3
+      description: Initiates an EDR negotiation by handling a contract negotiation first and then a transfer process for a given offer and with the given counter part. Please note that successfully invoking this endpoint only means that the negotiation was initiated.
+      operationId: initiateEdrNegotiationV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: The negotiation was successfully initiated.
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/edrs
   /v3/edrs/request:
     post:
       tags:
@@ -1636,6 +1670,53 @@ paths:
         uri: http://${loadBalancerDnsName}/api/management/v3/edrs/{transferProcessId}
         requestParameters:
           integration.request.path.transferProcessId: method.request.path.transferProcessId
+  /v3/edrs/{transferProcessId}/refresh:
+    post:
+      tags:
+        - EDR Cache V3
+      description: Refreshes and returns the EDR data address with the given transfer process ID
+      operationId: refreshEdrV3
+      parameters:
+        - name: transferProcessId
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The data address
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Request was malformed, e.g. id was null
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        "404":
+          description: An EDR data address with the given transfer process ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v3/edrs/{transferProcessId}/refresh
+        requestParameters:
+          integration.request.path.transferProcessId: method.request.path.transferProcessId
   /v3/transferprocesses/{id}/resume:
     post:
       description:
@@ -1879,6 +1960,54 @@ paths:
         connectionType: VPC_LINK
         uri: http://${loadBalancerDnsName}/api/management/v3/transferprocesses
   /v3/contractnegotiations/{id}:
+    delete:
+      description: Deletes the contract negotiation with the given ID. Only terminated negotiations without agreement will be deleted
+      operationId: deleteNegotiationV3
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: ContractNegotiation is deleted
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: Request was malformed, e.g. id was null
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: A contract negotiation with the given ID does not exist
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+          description: The given contract negotiation cannot be deleted due to a wrong state or has existing contract agreement
+      tags:
+        - Contract Negotiation V3
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: DELETE
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        requestParameters:
+          integration.request.path.id: method.request.path.id
+        uri: http://${loadBalancerDnsName}/api/management/v3/contractnegotiations/{id}
     get:
       description: Gets a contract negotiation with the given ID
       operationId: getNegotiationV3
@@ -1968,3 +2097,85 @@ paths:
         requestParameters:
           integration.request.path.id: method.request.path.id
         uri: http://${loadBalancerDnsName}/api/management/v3/contractnegotiations/{id}/state
+  /v1alpha/catalog/query:
+    post:
+      tags:
+        - Federated Catalog
+      description: Obtains all Catalog currently held by this cache instance
+      operationId: getCachedCatalog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: A list of Catalog is returned, potentially empty
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        "500":
+          description: A Query could not be completed due to an internal error
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v1alpha/catalog/query
+  /v4alpha/connectordiscovery/dspversionparams:
+    post:
+      tags:
+        - Connector Discovery
+      description: Discover supported connector parameters per DSP version
+      operationId: discoverDspVersionParamsV4Alpha
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: A list of connector parameters per DSP version
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        "500":
+          description: Discovery failed due to an internal error
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        "502":
+          description: Discovery failed due to connection to counter party
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+      x-amazon-apigateway-auth:
+        type: AWS_IAM
+      x-amazon-apigateway-integration:
+        type: http_proxy
+        httpMethod: POST
+        connectionId: ${vpcLinkId}
+        connectionType: VPC_LINK
+        uri: http://${loadBalancerDnsName}/api/management/v4alpha/connectordiscovery/dspversionparams

--- a/cdk/lib/config/ddb-tables.ts
+++ b/cdk/lib/config/ddb-tables.ts
@@ -37,6 +37,10 @@ export const DDB_TABLES: EdcTableProps[] = [
     partitionKey: COMMON_PARTITION_KEY,
   },
   {
+    tableName: "BusinessPartnerGroups",
+    partitionKey: COMMON_PARTITION_KEY,
+  },
+  {
     tableName: "ContractAgreements",
     partitionKey: COMMON_PARTITION_KEY,
   },

--- a/cdk/lib/config/environments.ts
+++ b/cdk/lib/config/environments.ts
@@ -17,6 +17,7 @@ export const EDC_IAM_ENVIRONMENT_VARIABLE_KEYS = {
   OAUTH_CLIENT_ID: "edc.iam.sts.oauth.client.id",
   OAUTH_TOKEN_URL: "edc.iam.sts.oauth.token.url",
   PARTICIPANT_ID: "edc.participant.id",
+  PARTICIPANT_BPN: "tractusx.edc.participant.bpn",
   TRUSTED_ISSUER_ID: "edc.iam.trusted-issuer.issuer-1.id",
 };
 
@@ -39,6 +40,7 @@ const edcIam = {
   [EDC_IAM_ENVIRONMENT_VARIABLE_KEYS.OAUTH_CLIENT_ID]: "",
   [EDC_IAM_ENVIRONMENT_VARIABLE_KEYS.OAUTH_TOKEN_URL]: "",
   [EDC_IAM_ENVIRONMENT_VARIABLE_KEYS.PARTICIPANT_ID]: "",
+  [EDC_IAM_ENVIRONMENT_VARIABLE_KEYS.PARTICIPANT_BPN]: "",
   [EDC_IAM_ENVIRONMENT_VARIABLE_KEYS.TRUSTED_ISSUER_ID]: "",
 };
 

--- a/cdk/lib/config/port-mappings.ts
+++ b/cdk/lib/config/port-mappings.ts
@@ -1,21 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export const CONTROL_PLANE_PORT_DEFAULT = 8080;
-export const CONTROL_PLANE_PORT_MANAGEMENT = 8081;
-export const CONTROL_PLANE_PORT_CONTROL = 8083;
-export const CONTROL_PLANE_PORT_PROTOCOL = 8084;
-export const CONTROL_PLANE_PORT_OBSERVABILITY = 8086;
+export const CONTROL_PLANE_PORT_DEFAULT = 8181;
+export const CONTROL_PLANE_PORT_MANAGEMENT = 8182;
+export const CONTROL_PLANE_PORT_CONTROL = 9191;
+export const CONTROL_PLANE_PORT_PROTOCOL = 8282;
 
-export const DATA_PLANE_PORT_DEFAULT = 9080;
-export const DATA_PLANE_PORT_PUBLIC = 9081;
-export const DATA_PLANE_PORT_CONTROL = 9084;
+export const DATA_PLANE_PORT_DEFAULT = 9181;
+export const DATA_PLANE_PORT_PUBLIC = 8185;
+export const DATA_PLANE_PORT_CONTROL = 9192;
 
 export interface ControlPlanePortMapping {
   readonly control: number;
   readonly default: number;
   readonly management: number;
-  readonly observability: number;
   readonly protocol: number;
 }
 
@@ -23,7 +21,6 @@ export const CONTROL_PLANE_PORT_MAPPING_DEFAULT: ControlPlanePortMapping = {
   control: CONTROL_PLANE_PORT_CONTROL,
   default: CONTROL_PLANE_PORT_DEFAULT,
   management: CONTROL_PLANE_PORT_MANAGEMENT,
-  observability: CONTROL_PLANE_PORT_OBSERVABILITY,
   protocol: CONTROL_PLANE_PORT_PROTOCOL,
 };
 

--- a/cdk/lib/constructs/edc-api.ts
+++ b/cdk/lib/constructs/edc-api.ts
@@ -170,7 +170,7 @@ export class EdcApi extends Construct {
     });
 
     const dspAddress = `${props.loadBalancerAddress}:${props.controlPlanePortMapping.protocol}`;
-    const dspApiPath = "dsp";
+    const dspApiPath = "protocol";
     const dspApiSpec = "./api/dsp-api.yaml";
     const dspApi = new SpecRestApi(this, "DspApi", {
       apiDefinition: getApiDefinitionTransform(

--- a/cdk/lib/constructs/edc-control-plane.ts
+++ b/cdk/lib/constructs/edc-control-plane.ts
@@ -73,7 +73,6 @@ export class EdcControlPlane extends Construct {
     taskDefinition.addContainer("ControlPlaneContainer", {
       containerName: containerName,
       environment: {
-        "edc.api.auth.key": props.apiAuthKey,
         "edc.dsp.callback.address": props.dspCallbackAddress,
         "edc.hostname": props.nlbOutputs.dnsName,
         "edc.iam.did.web.use.https": "true",
@@ -92,22 +91,18 @@ export class EdcControlPlane extends Construct {
 
         ...props.edcIamEnvVars,
 
-        "web.http.default.port": `${props.portMapping.default}`,
-        "web.http.default.path": "/api",
+        "web.http.port": `${props.portMapping.default}`,
+        "web.http.path": "/api",
         "web.http.management.port": `${props.portMapping.management}`,
-        "web.http.management.path": "/management",
+        "web.http.management.path": "/api/management",
         "web.http.management.auth.key": props.apiAuthKey,
         "web.http.control.port": `${props.portMapping.control}`,
-        "web.http.control.path": "/control",
+        "web.http.control.path": "/api/control",
         "web.http.protocol.port": `${props.portMapping.protocol}`,
-        "web.http.protocol.path": "/api/v1/dsp",
-        "web.http.observability.port": `${props.portMapping.observability}`,
-        "web.http.observability.path": "/api/check",
+        "web.http.protocol.path": "/api/protocol",
 
         JDK_JAVA_OPTIONS: [
           "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
-          "-Djava.util.logging.level=WARNING",
-          "-Dorg.eclipse.edc.level=INFO",
         ].join(" "),
       },
       image: props.image,

--- a/cdk/lib/constructs/edc-data-plane.ts
+++ b/cdk/lib/constructs/edc-data-plane.ts
@@ -77,7 +77,7 @@ export class EdcDataPlane extends Construct {
       containerName: containerName,
       environment: {
         "edc.dataplane.api.public.baseurl": props.apiPublicUrl,
-        "edc.dpf.selector.url": `http://${props.nlbOutputs.dnsName}:${props.controlPlanePortMapping.control}/control/v1/dataplanes`,
+        "edc.dpf.selector.url": `http://${props.nlbOutputs.dnsName}:${props.controlPlanePortMapping.control}/api/control/v1/dataplanes`,
         "edc.hostname": props.nlbOutputs.dnsName,
         "edc.iam.did.web.use.https": "true",
         "edc.iam.sts.oauth.client.secret.alias":
@@ -94,8 +94,8 @@ export class EdcDataPlane extends Construct {
 
         ...props.edcIamEnvVars,
 
-        "web.http.default.port": `${props.dataPlanePortMapping.default}`,
-        "web.http.default.path": "/api",
+        "web.http.port": `${props.dataPlanePortMapping.default}`,
+        "web.http.path": "/api",
         "web.http.public.port": `${props.dataPlanePortMapping.public}`,
         "web.http.public.path": "/api/public",
         "web.http.control.port": `${props.dataPlanePortMapping.control}`,
@@ -103,8 +103,6 @@ export class EdcDataPlane extends Construct {
 
         JDK_JAVA_OPTIONS: [
           "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
-          "-Djava.util.logging.level=WARNING",
-          "-Dorg.eclipse.edc.level=INFO",
         ].join(" "),
       },
       image: props.image,

--- a/cdk/lib/constructs/edc-data-plane.ts
+++ b/cdk/lib/constructs/edc-data-plane.ts
@@ -84,7 +84,7 @@ export class EdcDataPlane extends Construct {
           EDC_SECRETS_MANAGER_ALIASES.OAUTH_CLIENT_SECRET,
         "edc.runtime.id": id,
         "edc.vault.aws.region": Stack.of(this).region,
-        "tx.edc.dataplane.token.refresh.endpoint": props.apiPublicUrl,
+        "tx.edc.dataplane.token.refresh.endpoint": `${props.apiPublicUrl}token`,
 
         // This declares the aliases to use in AWS Secrets Manager for consumer pull scenarios
         "edc.transfer.proxy.token.signer.privatekey.alias":

--- a/cdk/lib/constructs/infra-constructs.ts
+++ b/cdk/lib/constructs/infra-constructs.ts
@@ -95,24 +95,24 @@ export class InfraConstructs extends Construct {
     const nlb = new EdcNlb(scope, "EdcNlb", {
       controlPlaneHealthCheck: {
         healthyThresholdCount: 3,
-        interval: Duration.seconds(5),
+        interval: Duration.seconds(10),
         path: "/api/check/health",
         port: `${props.controlPlanePortMapping.default}`,
         protocol: Protocol.HTTP,
-        timeout: Duration.seconds(2),
-        unhealthyThresholdCount: 2,
+        timeout: Duration.seconds(5),
+        unhealthyThresholdCount: 5,
       },
       controlPlanePorts: new Set<number>(
         Object.values(props.controlPlanePortMapping),
       ),
       dataPlaneHealthCheck: {
         healthyThresholdCount: 3,
-        interval: Duration.seconds(5),
+        interval: Duration.seconds(10),
         path: "/api/check/health",
         port: `${props.dataPlanePortMapping.default}`,
         protocol: Protocol.HTTP,
-        timeout: Duration.seconds(2),
-        unhealthyThresholdCount: 2,
+        timeout: Duration.seconds(5),
+        unhealthyThresholdCount: 5,
       },
       dataPlanePorts: new Set<number>(
         Object.values(props.dataPlanePortMapping),

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -49,7 +49,6 @@
         "semver"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.4"
@@ -623,7 +622,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1095,8 +1093,7 @@
       "version": "10.5.1",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.1.tgz",
       "integrity": "sha512-f/TfFXiS3G/yVIXDjOQn9oTlyu9Wo7Fxyjj7lb8r92iO81jR2uST+9MstxZTmDGx/CgIbxCXkFXgupnLTNxQZg==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1152,7 +1149,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
       "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1733,7 +1729,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1880,7 +1875,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -49,6 +49,7 @@
         "semver"
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.4"
@@ -622,6 +623,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1093,7 +1095,8 @@
       "version": "10.5.1",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.1.tgz",
       "integrity": "sha512-f/TfFXiS3G/yVIXDjOQn9oTlyu9Wo7Fxyjj7lb8r92iO81jR2uST+9MstxZTmDGx/CgIbxCXkFXgupnLTNxQZg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1149,6 +1152,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
       "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1729,6 +1733,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1875,6 +1880,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,8 @@
 
 set -e
 
-export AWS_REGION=eu-central-1
+export AWS_REGION=${AWS_REGION:-eu-central-1}
+export AWS_PROFILE=${AWS_PROFILE:-}
 export DOCKER_DEFAULT_PLATFORM=linux/amd64
 
 # Set in case of Finch container builds

--- a/edc/control-plane/build.gradle.kts
+++ b/edc/control-plane/build.gradle.kts
@@ -4,7 +4,7 @@
 plugins {
     `java-library`
     application
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {
@@ -23,8 +23,15 @@ application {
     mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
 }
 
-tasks.shadowJar {
-    mergeServiceFiles()
-    archiveFileName.set("control-plane.jar")
-    isZip64 = true
+tasks {
+    shadowJar {
+        mergeServiceFiles()
+        archiveFileName.set("control-plane.jar")
+        isZip64 = true
+    }
+
+    distTar { dependsOn(shadowJar) }
+    distZip { dependsOn(shadowJar) }
+    startScripts { dependsOn(shadowJar) }
+    named("startShadowScripts") { dependsOn(jar) }
 }

--- a/edc/control-plane/src/main/resources/log4j2.json
+++ b/edc/control-plane/src/main/resources/log4j2.json
@@ -1,0 +1,27 @@
+{
+  "Configuration": {
+    "Appenders": {
+      "Console": {
+        "name": "CONSOLE",
+        "PatternLayout": {
+          "pattern": "%level %d{yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS} %msg%n"
+        }
+      }
+    },
+    "Loggers": {
+      "Root": {
+        "level": "INFO",
+        "AppenderRef": {
+          "ref": "CONSOLE"
+        }
+      },
+      "Logger": {
+        "name": "org.eclipse.edc.monitor.logger",
+        "level": "INFO",
+        "AppenderRef": {
+          "ref": "CONSOLE"
+        }
+      }
+    }
+  }
+}

--- a/edc/control-plane/src/main/resources/log4j2.xml
+++ b/edc/control-plane/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601} %-5level [%t] %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/edc/data-plane/build.gradle.kts
+++ b/edc/data-plane/build.gradle.kts
@@ -4,7 +4,7 @@
 plugins {
     `java-library`
     application
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {
@@ -23,8 +23,14 @@ application {
     mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
 }
 
-tasks.shadowJar {
-    mergeServiceFiles()
-    archiveFileName.set("data-plane.jar")
-    isZip64 = true
+tasks {
+    shadowJar {
+        mergeServiceFiles()
+        archiveFileName.set("data-plane.jar")
+        isZip64 = true
+    }
+    distTar { dependsOn(shadowJar) }
+    distZip { dependsOn(shadowJar) }
+    startScripts { dependsOn(shadowJar) }
+    named("startShadowScripts") { dependsOn(jar) }
 }

--- a/edc/data-plane/src/main/resources/log4j2.xml
+++ b/edc/data-plane/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601} %-5level [%t] %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/edc/extensions/common/ddb/build.gradle.kts
+++ b/edc/extensions/common/ddb/build.gradle.kts
@@ -7,8 +7,8 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
     `java-library`
-    id("org.jetbrains.kotlin.jvm") version "2.0.+"
-    id("org.jlleitschuh.gradle.ktlint") version "12.1.+"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ktlint)
 }
 
 repositories {

--- a/edc/extensions/common/ddb/src/main/kotlin/software/amazon/edc/extensions/common/ddb/AttributeConverters.kt
+++ b/edc/extensions/common/ddb/src/main/kotlin/software/amazon/edc/extensions/common/ddb/AttributeConverters.kt
@@ -37,10 +37,13 @@ class ListOfMapsConverter : AttributeConverter<List<Map<String, Any?>>> {
 }
 
 private fun Map<String, Any?>.toMapAttributeValue(): AttributeValue =
-    AttributeValue.builder().m(
-        mapNotNull { it.value?.let { value -> it.key to value } }.toMap()
-            .mapValues { (_, value) -> value.toAttributeValue() },
-    ).build()
+    AttributeValue
+        .builder()
+        .m(
+            mapNotNull { it.value?.let { value -> it.key to value } }
+                .toMap()
+                .mapValues { (_, value) -> value.toAttributeValue() },
+        ).build()
 
 @Suppress("UNCHECKED_CAST")
 private fun Any?.toAttributeValue(): AttributeValue =
@@ -55,7 +58,8 @@ private fun Any?.toAttributeValue(): AttributeValue =
     }
 
 private fun AttributeValue.toMap(): Map<String, Any?> =
-    m()?.filter { it.value.type() != AttributeValue.Type.NUL }
+    m()
+        ?.filter { it.value.type() != AttributeValue.Type.NUL }
         ?.mapValues { (_, attributeValue) -> attributeValue.toValue() } ?: emptyMap()
 
 private fun AttributeValue.toValue(): Any? =

--- a/edc/extensions/common/ddb/src/main/kotlin/software/amazon/edc/extensions/common/ddb/edr/DdbEdrEntryIndex.kt
+++ b/edc/extensions/common/ddb/src/main/kotlin/software/amazon/edc/extensions/common/ddb/edr/DdbEdrEntryIndex.kt
@@ -16,7 +16,9 @@ import software.amazon.edc.extensions.common.ddb.utility.getGenericPropertyCompa
 import software.amazon.edc.extensions.common.ddb.utility.keyFromId
 import software.amazon.edc.extensions.common.ddb.utility.toScanRequest
 
-class DdbEdrEntryIndex(private val table: DynamoDbTable<EdrEntry>) : EndpointDataReferenceEntryIndex {
+class DdbEdrEntryIndex(
+    private val table: DynamoDbTable<EdrEntry>,
+) : EndpointDataReferenceEntryIndex {
     override fun findById(id: String): EndpointDataReferenceEntry? = table.getItem(keyFromId(id))?.toEdcType()
 
     override fun query(querySpec: QuerySpec): StoreResult<MutableList<EndpointDataReferenceEntry>> {
@@ -24,7 +26,10 @@ class DdbEdrEntryIndex(private val table: DynamoDbTable<EdrEntry>) : EndpointDat
         val result = table.scan(scanRequest)
 
         return StoreResult.success(
-            result.items().asSequence().map { it.toEdcType() }
+            result
+                .items()
+                .asSequence()
+                .map { it.toEdcType() }
                 .sortedWith(querySpec.getGenericPropertyComparator())
                 .applyOffsetAndLimit(querySpec)
                 .toMutableList(),

--- a/edc/extensions/common/ddb/src/main/kotlin/software/amazon/edc/extensions/common/ddb/types/EdrEntry.kt
+++ b/edc/extensions/common/ddb/src/main/kotlin/software/amazon/edc/extensions/common/ddb/types/EdrEntry.kt
@@ -25,14 +25,16 @@ data class EdrEntry(
     var providerId: String = "",
 ) {
     fun toEdcType(): EndpointDataReferenceEntry =
-        EndpointDataReferenceEntry.Builder.newInstance().apply {
-            transferProcessId(transferProcessId)
-            agreementId(agreementId)
-            assetId(assetId)
-            contractNegotiationId(contractNegotiationId)
-            createdAt(createdAt)
-            providerId(providerId)
-        }.build()
+        EndpointDataReferenceEntry.Builder
+            .newInstance()
+            .apply {
+                transferProcessId(transferProcessId)
+                agreementId(agreementId)
+                assetId(assetId)
+                contractNegotiationId(contractNegotiationId)
+                createdAt(createdAt)
+                providerId(providerId)
+            }.build()
 
     companion object {
         const val AGREEMENT_ID = "agreementId"

--- a/edc/extensions/common/ddb/src/main/kotlin/software/amazon/edc/extensions/common/ddb/utility/QuerySpecFunctions.kt
+++ b/edc/extensions/common/ddb/src/main/kotlin/software/amazon/edc/extensions/common/ddb/utility/QuerySpecFunctions.kt
@@ -91,11 +91,20 @@ fun <T> QuerySpec.getGenericPropertyComparator(): Comparator<T> =
 
 private fun <T> QuerySpec.getSortFieldValue(obj: T): Any? =
     try {
-        val field = obj!!::class.java.getDeclaredField(sortField)
-        field.isAccessible = true
-        field.get(obj)
+        var clazz: Class<*>? = obj!!::class.java
+        var field: java.lang.reflect.Field? = null
+        while (clazz != null && field == null) {
+            field =
+                try {
+                    clazz.getDeclaredField(sortField)
+                } catch (_: NoSuchFieldException) {
+                    null
+                }
+            clazz = clazz.superclass
+        }
+        field?.isAccessible = true
+        field?.get(obj) ?: throw NoSuchFieldException(sortField)
     } catch (e: Exception) {
-//    log().error("Unable to get field value for $sortField", e)
         throw IllegalArgumentException("$sortField is not a valid sort field!")
     }
 

--- a/edc/extensions/common/ddb/src/main/kotlin/software/amazon/edc/extensions/common/ddb/utility/QuerySpecFunctions.kt
+++ b/edc/extensions/common/ddb/src/main/kotlin/software/amazon/edc/extensions/common/ddb/utility/QuerySpecFunctions.kt
@@ -55,7 +55,8 @@ fun QuerySpec.toScanRequest(fieldNameReplacements: Map<String, String> = emptyMa
     val builder = ScanEnhancedRequest.builder()
     if (resultingFilterExpression.isNotEmpty()) {
         builder.filterExpression(
-            Expression.builder()
+            Expression
+                .builder()
                 .expression(resultingFilterExpression.toString())
                 .expressionNames(expressionNames)
                 .expressionValues(expressionValues)
@@ -121,9 +122,7 @@ private fun Criterion.getDdbOperator(): String =
         else -> throw IllegalArgumentException("Unsupported operator: $operator")
     }
 
-private fun Criterion.getSanitizedOperandRight(): String {
-    return operandRight.toString().replace("%", "")
-}
+private fun Criterion.getSanitizedOperandRight(): String = operandRight.toString().replace("%", "")
 
 private fun Any?.toAttributeValue(): AttributeValue {
     val builder = AttributeValue.builder()

--- a/edc/extensions/common/ddb/src/test/kotlin/software/amazon/edc/extensions/common/ddb/MapStringAnyConverterTest.kt
+++ b/edc/extensions/common/ddb/src/test/kotlin/software/amazon/edc/extensions/common/ddb/MapStringAnyConverterTest.kt
@@ -15,11 +15,13 @@ class MapStringAnyConverterTest {
     fun unsupportedTypes() {
         assertThrows<IllegalArgumentException> { converter.transformFrom(mapOf("key" to Pair("first", "second"))) }
         assertThrows<IllegalArgumentException> {
-            converter.transformTo(
-                AttributeValue.builder()
-                    .m(mapOf("data" to AttributeValue.fromB(SdkBytes.fromUtf8String("some binary data"))))
-                    .build(),
-            ).also { println("Result: $it") }
+            converter
+                .transformTo(
+                    AttributeValue
+                        .builder()
+                        .m(mapOf("data" to AttributeValue.fromB(SdkBytes.fromUtf8String("some binary data"))))
+                        .build(),
+                ).also { println("Result: $it") }
         }
     }
 }

--- a/edc/extensions/common/ddb/src/test/kotlin/software/amazon/edc/extensions/common/ddb/edr/DdbEdrEntryIndexTest.kt
+++ b/edc/extensions/common/ddb/src/test/kotlin/software/amazon/edc/extensions/common/ddb/edr/DdbEdrEntryIndexTest.kt
@@ -12,7 +12,8 @@ import software.amazon.edc.extensions.common.ddb.types.EdrEntry
 
 class DdbEdrEntryIndexTest : EndpointDataReferenceEntryIndexTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val table =

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/ControlPlaneDdbExtension.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/ControlPlaneDdbExtension.kt
@@ -20,7 +20,7 @@ import org.eclipse.edc.spi.query.CriterionOperatorRegistry
 import org.eclipse.edc.spi.system.ServiceExtension
 import org.eclipse.edc.spi.system.ServiceExtensionContext
 import org.eclipse.edc.spi.types.TypeManager
-import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerStore
+import org.eclipse.tractusx.edc.validation.businesspartner.spi.store.BusinessPartnerStore
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/assets/DdbAssetIndex.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/assets/DdbAssetIndex.kt
@@ -41,7 +41,8 @@ class DdbAssetIndex(
         val pages = table.scan()
         val predicate = querySpec.filterExpression.toPredicate<Any>(criterionOperatorRegistry)
 
-        return pages.items()
+        return pages
+            .items()
             .asSequence()
             .map { it.toEdcAsset() }
             .filter { predicate.test(it) }
@@ -73,10 +74,12 @@ class DdbAssetIndex(
 
     override fun countAssets(criteria: List<Criterion>): Long {
         val querySpec =
-            QuerySpec.Builder.newInstance().apply {
-                filter(criteria)
-                limit(Integer.MAX_VALUE)
-            }.build()
+            QuerySpec.Builder
+                .newInstance()
+                .apply {
+                    filter(criteria)
+                    limit(Integer.MAX_VALUE)
+                }.build()
         return queryAssets(querySpec).count()
     }
 

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/bpn/DdbBpnStore.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/bpn/DdbBpnStore.kt
@@ -4,9 +4,9 @@
 package software.amazon.edc.extensions.controlplane.ddb.bpn
 
 import org.eclipse.edc.spi.result.StoreResult
-import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerStore
-import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerStore.ALREADY_EXISTS_TEMPLATE
-import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerStore.NOT_FOUND_TEMPLATE
+import org.eclipse.tractusx.edc.validation.businesspartner.spi.store.BusinessPartnerStore
+import org.eclipse.tractusx.edc.validation.businesspartner.spi.store.BusinessPartnerStore.ALREADY_EXISTS_TEMPLATE
+import org.eclipse.tractusx.edc.validation.businesspartner.spi.store.BusinessPartnerStore.NOT_FOUND_TEMPLATE
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 import software.amazon.edc.extensions.common.ddb.utility.keyFromId
 import software.amazon.edc.extensions.controlplane.ddb.types.BpnGroup
@@ -14,38 +14,54 @@ import software.amazon.edc.extensions.controlplane.ddb.types.BpnGroup
 class DdbBpnStore(
     private val table: DynamoDbTable<BpnGroup>,
 ) : BusinessPartnerStore {
-    override fun resolveForBpn(bpn: String): StoreResult<MutableList<String>> =
-        getBpnGroup(bpn)?.groups?.let { StoreResult.success(it.toMutableList()) }
-            ?: StoreResult.notFound(NOT_FOUND_TEMPLATE.format(bpn))
+    override fun resolveForBpn(businessPartnerNumber: String): StoreResult<List<String>> =
+        getBpnGroup(businessPartnerNumber)?.groups?.let { StoreResult.success(it.toList()) }
+            ?: StoreResult.notFound(NOT_FOUND_TEMPLATE.format(businessPartnerNumber))
+
+    override fun resolveForBpnGroup(businessPartnerGroup: String): StoreResult<List<String>> {
+        val allBpns =
+            table.scan().items()
+                .filter { it.groups?.contains(businessPartnerGroup) == true }
+                .map { it.bpn }
+        return StoreResult.success(allBpns)
+    }
+
+    override fun resolveForBpnGroups(): StoreResult<List<String>> {
+        val allGroups =
+            table.scan().items()
+                .flatMap { it.groups ?: emptyList() }
+                .distinct()
+        return StoreResult.success(allGroups)
+    }
 
     override fun save(
-        bpn: String,
+        businessPartnerNumber: String,
         groups: List<String>?,
     ): StoreResult<Void> {
-        return if (getBpnGroup(bpn) == null) {
+        return if (getBpnGroup(businessPartnerNumber) == null) {
             val bpnGroup =
                 BpnGroup(
-                    bpn = bpn,
+                    bpn = businessPartnerNumber,
                     groups = groups,
                 )
             table.putItem(bpnGroup)
             StoreResult.success()
         } else {
-            StoreResult.alreadyExists(ALREADY_EXISTS_TEMPLATE.format(bpn))
+            StoreResult.alreadyExists(ALREADY_EXISTS_TEMPLATE.format(businessPartnerNumber))
         }
     }
 
-    override fun delete(bpn: String): StoreResult<Void> {
-        val bpnGroup = getBpnGroup(bpn) ?: return StoreResult.notFound(NOT_FOUND_TEMPLATE.format(bpn))
+    override fun delete(businessPartnerNumber: String): StoreResult<Void> {
+        val bpnGroup = getBpnGroup(businessPartnerNumber) ?: return StoreResult.notFound(NOT_FOUND_TEMPLATE.format(businessPartnerNumber))
         table.deleteItem(bpnGroup)
         return StoreResult.success()
     }
 
     override fun update(
-        bpn: String,
+        businessPartnerNumber: String,
         groups: List<String>?,
     ): StoreResult<Void> {
-        val bpnGroup = getBpnGroup(bpn) ?: return StoreResult.notFound(NOT_FOUND_TEMPLATE.format(bpn))
+        val bpnGroup = getBpnGroup(businessPartnerNumber) ?: return StoreResult.notFound(NOT_FOUND_TEMPLATE.format(businessPartnerNumber))
         bpnGroup.groups = groups
         table.updateItem(bpnGroup)
         return StoreResult.success()

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/bpn/DdbBpnStore.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/bpn/DdbBpnStore.kt
@@ -20,7 +20,9 @@ class DdbBpnStore(
 
     override fun resolveForBpnGroup(businessPartnerGroup: String): StoreResult<List<String>> {
         val allBpns =
-            table.scan().items()
+            table
+                .scan()
+                .items()
                 .filter { it.groups?.contains(businessPartnerGroup) == true }
                 .map { it.bpn }
         return StoreResult.success(allBpns)
@@ -28,7 +30,9 @@ class DdbBpnStore(
 
     override fun resolveForBpnGroups(): StoreResult<List<String>> {
         val allGroups =
-            table.scan().items()
+            table
+                .scan()
+                .items()
                 .flatMap { it.groups ?: emptyList() }
                 .distinct()
         return StoreResult.success(allGroups)
@@ -37,8 +41,8 @@ class DdbBpnStore(
     override fun save(
         businessPartnerNumber: String,
         groups: List<String>?,
-    ): StoreResult<Void> {
-        return if (getBpnGroup(businessPartnerNumber) == null) {
+    ): StoreResult<Void> =
+        if (getBpnGroup(businessPartnerNumber) == null) {
             val bpnGroup =
                 BpnGroup(
                     bpn = businessPartnerNumber,
@@ -49,7 +53,6 @@ class DdbBpnStore(
         } else {
             StoreResult.alreadyExists(ALREADY_EXISTS_TEMPLATE.format(businessPartnerNumber))
         }
-    }
 
     override fun delete(businessPartnerNumber: String): StoreResult<Void> {
         val bpnGroup = getBpnGroup(businessPartnerNumber) ?: return StoreResult.notFound(NOT_FOUND_TEMPLATE.format(businessPartnerNumber))

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/contracts/DdbContractDefinitionStore.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/contracts/DdbContractDefinitionStore.kt
@@ -30,7 +30,11 @@ class DdbContractDefinitionStore(
     override fun findAll(querySpec: QuerySpec): Stream<EdcContractDefinition> {
 //        log().info("findAll: $querySpec")
         return queryResolver.query(
-            table.scan().items().stream().map { it.toEdcContractDefinition(objectMapper) },
+            table
+                .scan()
+                .items()
+                .stream()
+                .map { it.toEdcContractDefinition(objectMapper) },
             querySpec,
         )
     }

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/contracts/DdbContractNegotiationStore.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/contracts/DdbContractNegotiationStore.kt
@@ -113,6 +113,7 @@ class DdbContractNegotiationStore(
         }
     }
 
+    @Deprecated("Deprecated by interface")
     override fun findForCorrelationId(correlationId: String): EdcContractNegotiation? {
         val negotiation = getContractNegotiationByCorrelationId(correlationId)
         val agreement = negotiation?.agreementId?.let { getContractAgreement(it) }
@@ -161,14 +162,6 @@ class DdbContractNegotiationStore(
             .sortedWith(querySpec.getGenericPropertyComparator())
             .applyOffsetAndLimit(querySpec)
             .asStream()
-    }
-
-    @Deprecated("Deprecated in ContractNegotiationStore")
-    override fun findByCorrelationIdAndLease(correlationId: String): StoreResult<EdcContractNegotiation> {
-        val negotiation =
-            getContractNegotiationByCorrelationId(correlationId)
-                ?: return StoreResult.notFound("ContractNegotiation with correlation ID $correlationId not found!")
-        return findByIdAndLease(negotiation.id)
     }
 
     override fun getLeasableById(id: String): Leasable? = getContractNegotiation(id)

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/contracts/DdbContractNegotiationStore.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/contracts/DdbContractNegotiationStore.kt
@@ -19,7 +19,6 @@ import software.amazon.edc.extensions.common.ddb.utility.applyOffsetAndLimit
 import software.amazon.edc.extensions.common.ddb.utility.getGenericPropertyComparator
 import software.amazon.edc.extensions.common.ddb.utility.hasProperty
 import software.amazon.edc.extensions.common.ddb.utility.keyFromId
-import software.amazon.edc.extensions.common.ddb.utility.queryRequestFromId
 import software.amazon.edc.extensions.common.ddb.utility.registerConstraintSubtypes
 import software.amazon.edc.extensions.common.ddb.utility.toScanRequest
 import software.amazon.edc.extensions.controlplane.ddb.types.ContractAgreement
@@ -40,12 +39,12 @@ class DdbContractNegotiationStore(
     private val contractAgreementTable: DynamoDbTable<ContractAgreement>,
     private val contractNegotiationTable: DynamoDbTable<ContractNegotiation>,
     private val objectMapper: ObjectMapper,
-) : ContractNegotiationStore, AbstractLeasableEntityDao(
+) : AbstractLeasableEntityDao(
         clock = clock,
         leaseHolder = leaseHolder,
         leaseTable = leaseTable,
-    ) {
-    private val correlationIdIndex = contractNegotiationTable.index(ContractNegotiation.INDEX_CORRELATION_ID)
+    ),
+    ContractNegotiationStore {
     private val negotiationQueryResolver =
         ReflectionBasedQueryResolver(EdcContractNegotiation::class.java, criterionOperatorRegistry)
 
@@ -60,14 +59,17 @@ class DdbContractNegotiationStore(
         vararg criteria: Criterion,
     ): MutableList<EdcContractNegotiation> {
         val querySpec =
-            QuerySpec.Builder.newInstance()
+            QuerySpec.Builder
+                .newInstance()
                 .filter(criteria.toList())
                 .sortField("stateTimestamp")
                 .sortOrder(SortOrder.ASC)
                 .limit(max)
                 .build()
         val request = querySpec.toScanRequest()
-        return contractNegotiationTable.scan(request).items()
+        return contractNegotiationTable
+            .scan(request)
+            .items()
             .asSequence()
             .filterNot { hasLease(it.id) }
             .sortedBy { it.id } // Required by EDC tests
@@ -76,8 +78,7 @@ class DdbContractNegotiationStore(
                 acquireLease(it)
                 val agreement = it.agreementId?.let { agreementId -> getContractAgreement(agreementId) }
                 it.toEdcContractNegotiation(objectMapper, agreement)
-            }
-            .applyOffsetAndLimit(querySpec)
+            }.applyOffsetAndLimit(querySpec)
             .toMutableList()
     }
 
@@ -113,41 +114,41 @@ class DdbContractNegotiationStore(
         }
     }
 
-    @Deprecated("Deprecated by interface")
-    override fun findForCorrelationId(correlationId: String): EdcContractNegotiation? {
-        val negotiation = getContractNegotiationByCorrelationId(correlationId)
-        val agreement = negotiation?.agreementId?.let { getContractAgreement(it) }
-        return negotiation?.toEdcContractNegotiation(objectMapper, agreement)
-    }
-
     override fun findContractAgreement(contractId: String): EdcContractAgreement? =
         getContractAgreement(contractId)?.toEdcContractAgreement(objectMapper)
 
-    override fun delete(negotiationId: String) {
-        val contractNegotiation = getContractNegotiation(negotiationId) ?: return
+    override fun deleteById(negotiationId: String): StoreResult<Void> {
+        val contractNegotiation =
+            getContractNegotiation(negotiationId)
+                ?: return StoreResult.notFound("ContractNegotiation with ID $negotiationId not found!")
         val contractAgreementId = contractNegotiation.agreementId
         if (contractAgreementId != null && getContractAgreement(contractAgreementId) != null) {
-            throw IllegalStateException(
+            return StoreResult.generalError(
                 "Cannot delete ContractNegotiation $negotiationId: ContractAgreement already created.",
             )
         }
         if (hasLease(negotiationId)) {
-            throw IllegalStateException(
+            return StoreResult.alreadyLeased(
                 "ContractNegotiation with ID $negotiationId cannot be deleted because it is currently leased!",
             )
         }
         contractNegotiationTable.deleteItem(keyFromId(negotiationId))
+        return StoreResult.success()
     }
 
     override fun queryNegotiations(querySpec: QuerySpec): Stream<EdcContractNegotiation> {
         // This must support nested objects, so we'll need to fetch everything and feed it into the query resolver.
         val all =
-            contractNegotiationTable.scan().items().asSequence().map {
-                it.toEdcContractNegotiation(
-                    objectMapper,
-                    it.agreementId?.let { agreementId -> getContractAgreement(agreementId) },
-                )
-            }.asStream()
+            contractNegotiationTable
+                .scan()
+                .items()
+                .asSequence()
+                .map {
+                    it.toEdcContractNegotiation(
+                        objectMapper,
+                        it.agreementId?.let { agreementId -> getContractAgreement(agreementId) },
+                    )
+                }.asStream()
         return negotiationQueryResolver.query(all, querySpec)
     }
 
@@ -156,7 +157,9 @@ class DdbContractNegotiationStore(
             throw IllegalArgumentException("Sort field ${querySpec.sortField} is not valid for contract agreements!")
         }
         val scanRequest = querySpec.toScanRequest()
-        return contractAgreementTable.scan(scanRequest).items()
+        return contractAgreementTable
+            .scan(scanRequest)
+            .items()
             .asSequence()
             .map { it.toEdcContractAgreement(objectMapper) }
             .sortedWith(querySpec.getGenericPropertyComparator())
@@ -173,9 +176,6 @@ class DdbContractNegotiationStore(
     private fun getContractAgreement(id: String): ContractAgreement? = contractAgreementTable.getItem(keyFromId(id))
 
     private fun getContractNegotiation(id: String): ContractNegotiation? = contractNegotiationTable.getItem(keyFromId(id))
-
-    private fun getContractNegotiationByCorrelationId(correlationId: String): ContractNegotiation? =
-        correlationIdIndex.query(queryRequestFromId(correlationId)).toList().flatMap { it.items() }.firstOrNull()
 
     init {
         objectMapper.registerConstraintSubtypes()

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/dataplane/DdbDataPlaneInstanceStore.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/dataplane/DdbDataPlaneInstanceStore.kt
@@ -28,11 +28,12 @@ class DdbDataPlaneInstanceStore(
     leaseHolder: String,
     leaseTable: DynamoDbTable<Lease>,
     private val table: DynamoDbTable<DataPlaneInstance>,
-) : DataPlaneInstanceStore, AbstractLeasableEntityDao(
+) : AbstractLeasableEntityDao(
         clock = clock,
         leaseHolder = leaseHolder,
         leaseTable = leaseTable,
-    ) {
+    ),
+    DataPlaneInstanceStore {
     override fun findById(id: String): EdcDataPlaneInstance? = getDataPlaneInstance(id)?.toEdcDataPlaneInstance()
 
     override fun nextNotLeased(
@@ -40,13 +41,16 @@ class DdbDataPlaneInstanceStore(
         vararg criteria: Criterion,
     ): MutableList<EdcDataPlaneInstance> {
         val querySpec =
-            QuerySpec.Builder.newInstance()
+            QuerySpec.Builder
+                .newInstance()
                 .filter(criteria.asList())
                 .sortField("stateTimestamp")
                 .sortOrder(SortOrder.ASC)
                 .limit(max)
                 .build()
-        return table.scan(querySpec.toScanRequest()).items()
+        return table
+            .scan(querySpec.toScanRequest())
+            .items()
             .asSequence()
             .filterNot { hasLease(it.id) }
             .sortedWith(querySpec.getGenericPropertyComparator())
@@ -90,7 +94,13 @@ class DdbDataPlaneInstanceStore(
         table.deleteItem(keyFromId(id))?.let { StoreResult.success(it.toEdcDataPlaneInstance()) }
             ?: StoreResult.notFound("DataPlaneInstance $id not found!")
 
-    override fun getAll(): Stream<EdcDataPlaneInstance> = table.scan().items().asSequence().map { it.toEdcDataPlaneInstance() }.asStream()
+    override fun getAll(): Stream<EdcDataPlaneInstance> =
+        table
+            .scan()
+            .items()
+            .asSequence()
+            .map { it.toEdcDataPlaneInstance() }
+            .asStream()
 
     override fun getLeasableById(id: String): Leasable? = getDataPlaneInstance(id)
 

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/policies/DdbPolicyDefinitionStore.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/policies/DdbPolicyDefinitionStore.kt
@@ -31,7 +31,12 @@ class DdbPolicyDefinitionStore(
 
     override fun findAll(querySpec: QuerySpec): Stream<EdcPolicyDefinition> =
         queryResolver.query(
-            table.scan().items().asSequence().map { it.toEdcPolicyDefinition(objectMapper) }.asStream(),
+            table
+                .scan()
+                .items()
+                .asSequence()
+                .map { it.toEdcPolicyDefinition(objectMapper) }
+                .asStream(),
             querySpec,
         )
 

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/policies/DdbPolicyMonitorStore.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/policies/DdbPolicyMonitorStore.kt
@@ -26,11 +26,12 @@ class DdbPolicyMonitorStore(
     leaseHolder: String,
     leaseTable: DynamoDbTable<Lease>,
     private val table: DynamoDbTable<PolicyMonitor>,
-) : PolicyMonitorStore, AbstractLeasableEntityDao(
+) : AbstractLeasableEntityDao(
         clock = clock,
         leaseHolder = leaseHolder,
         leaseTable = leaseTable,
-    ) {
+    ),
+    PolicyMonitorStore {
     override fun findById(id: String): PolicyMonitorEntry? = getPolicyMonitor(id)?.toEdcPolicyMonitor()
 
     override fun nextNotLeased(
@@ -38,21 +39,23 @@ class DdbPolicyMonitorStore(
         vararg criteria: Criterion,
     ): MutableList<PolicyMonitorEntry> {
         val querySpec =
-            QuerySpec.Builder.newInstance()
+            QuerySpec.Builder
+                .newInstance()
                 .filter(criteria.toList())
                 .sortField(PolicyMonitor.STATE_TIMESTAMP)
                 .sortOrder(SortOrder.ASC)
                 .limit(max)
                 .build()
-        return table.scan(querySpec.toScanRequest()).items()
+        return table
+            .scan(querySpec.toScanRequest())
+            .items()
             .asSequence()
             .filterNot { hasLease(it.id) }
             .sortedWith(querySpec.getGenericPropertyComparator())
             .map {
                 acquireLease(it)
                 it.toEdcPolicyMonitor()
-            }
-            .applyOffsetAndLimit(querySpec)
+            }.applyOffsetAndLimit(querySpec)
             .toMutableList()
     }
 

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/transfers/DdbTransferProcessStore.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/transfers/DdbTransferProcessStore.kt
@@ -105,14 +105,6 @@ class DdbTransferProcessStore(
             querySpec,
         )
 
-    @Deprecated("Deprecated in TransferProcessStore")
-    override fun findByCorrelationIdAndLease(correlationId: String): StoreResult<EdcTransferProcess> {
-        val transferProcess =
-            getTransferProcessByCorrelationId(correlationId)
-                ?: return StoreResult.notFound("TransferProcess with correlationId: $correlationId not found!")
-        return findByIdAndLease(transferProcess.id)
-    }
-
     override fun getLeasableById(id: String): Leasable? = getTransferProcess(id)
 
     override fun updateLeaseId(leasable: Leasable) {

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/transfers/DdbTransferProcessStore.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/transfers/DdbTransferProcessStore.kt
@@ -31,11 +31,12 @@ class DdbTransferProcessStore(
     private val criterionOperatorRegistry: CriterionOperatorRegistry,
     private val objectMapper: ObjectMapper,
     private val table: DynamoDbTable<TransferProcess>,
-) : TransferProcessStore, AbstractLeasableEntityDao(
+) : AbstractLeasableEntityDao(
         clock = clock,
         leaseHolder = leaseHolder,
         leaseTable = leaseTable,
-    ) {
+    ),
+    TransferProcessStore {
     private val correlationIdIndex = table.index(TransferProcess.INDEX_CORRELATION_ID)
     private val queryResolver = ReflectionBasedQueryResolver(EdcTransferProcess::class.java, criterionOperatorRegistry)
 
@@ -46,7 +47,9 @@ class DdbTransferProcessStore(
         vararg criteria: Criterion,
     ): MutableList<EdcTransferProcess> {
         val predicate = criteria.toList().toPredicate<Any>(criterionOperatorRegistry)
-        return table.scan().items()
+        return table
+            .scan()
+            .items()
             .asSequence()
             .filterNot { hasLease(it.id) }
             .map { it.toEdcTransferProcess(objectMapper) }
@@ -98,10 +101,13 @@ class DdbTransferProcessStore(
 
     override fun findAll(querySpec: QuerySpec): Stream<EdcTransferProcess> =
         queryResolver.query(
-            table.scan().items()
+            table
+                .scan()
+                .items()
                 .asSequence()
                 .sortedBy { it.id } // Tests assume a specific order
-                .map { it.toEdcTransferProcess(objectMapper) }.asStream(),
+                .map { it.toEdcTransferProcess(objectMapper) }
+                .asStream(),
             querySpec,
         )
 
@@ -114,5 +120,9 @@ class DdbTransferProcessStore(
     private fun getTransferProcess(id: String): TransferProcess? = table.getItem(keyFromId(id))
 
     private fun getTransferProcessByCorrelationId(correlationId: String): TransferProcess? =
-        correlationIdIndex.query(queryRequestFromId(correlationId)).toList().flatMap { it.items() }.firstOrNull()
+        correlationIdIndex
+            .query(queryRequestFromId(correlationId))
+            .toList()
+            .flatMap { it.items() }
+            .firstOrNull()
 }

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/Asset.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/Asset.kt
@@ -29,13 +29,20 @@ data class Asset(
     var properties: Map<String, Any> = emptyMap(),
 ) {
     fun toEdcAsset(): EdcAsset =
-        EdcAsset.Builder.newInstance().apply {
-            id(assetId)
-            createdAt(createdAt)
-            dataAddress(DataAddress.Builder.newInstance().properties(dataAddress).build())
-            privateProperties(privateProperties)
-            properties(properties)
-        }.build()
+        EdcAsset.Builder
+            .newInstance()
+            .apply {
+                id(assetId)
+                createdAt(createdAt)
+                dataAddress(
+                    DataAddress.Builder
+                        .newInstance()
+                        .properties(dataAddress)
+                        .build(),
+                )
+                privateProperties(privateProperties)
+                properties(properties)
+            }.build()
 
     companion object {
         const val ID = "id"

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/ContractAgreement.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/ContractAgreement.kt
@@ -37,14 +37,16 @@ data class ContractAgreement(
     var startDate: Long? = null,
 ) {
     fun toEdcContractAgreement(objectMapper: ObjectMapper): EdcContractAgreement =
-        EdcContractAgreement.Builder.newInstance().apply {
-            id(id)
-            contractSigningDate(signingDate)
-            assetId(assetId)
-            consumerId(consumerAgentId)
-            policy(objectMapper.convertValue(policy, Policy::class.java))
-            providerId(providerAgentId)
-        }.build()
+        EdcContractAgreement.Builder
+            .newInstance()
+            .apply {
+                id(id)
+                contractSigningDate(signingDate)
+                assetId(assetId)
+                consumerId(consumerAgentId)
+                policy(objectMapper.convertValue(policy, Policy::class.java))
+                providerId(providerAgentId)
+            }.build()
 
     companion object {
         const val ASSET_ID = "assetId"

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/ContractDefinition.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/ContractDefinition.kt
@@ -33,14 +33,16 @@ data class ContractDefinition(
     var privateProperties: Map<String, Any>? = null,
 ) {
     fun toEdcContractDefinition(objectMapper: ObjectMapper): EdcContractDefinition =
-        EdcContractDefinition.Builder.newInstance().apply {
-            id(id)
-            createdAt(createdAt)
-            accessPolicyId(accessPolicyId)
-            assetsSelector(assetsSelector.map { objectMapper.convertValue(it, Criterion::class.java) })
-            contractPolicyId(contractPolicyId)
-            privateProperties(privateProperties)
-        }.build()
+        EdcContractDefinition.Builder
+            .newInstance()
+            .apply {
+                id(id)
+                createdAt(createdAt)
+                accessPolicyId(accessPolicyId)
+                assetsSelector(assetsSelector.map { objectMapper.convertValue(it, Criterion::class.java) })
+                contractPolicyId(contractPolicyId)
+                privateProperties(privateProperties)
+            }.build()
 
     companion object {
         const val ACCESS_POLICY_ID = "accessPolicyId"

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/ContractNegotiation.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/ContractNegotiation.kt
@@ -69,26 +69,28 @@ data class ContractNegotiation(
         objectMapper: ObjectMapper,
         contractAgreement: ContractAgreement? = null,
     ): EdcContractNegotiation =
-        EdcContractNegotiation.Builder.newInstance().apply {
-            id(id)
-            createdAt(createdAt)
-            contractAgreement?.let { contractAgreement(it.toEdcContractAgreement(objectMapper)) }
-            callbackAddresses(callbackAddresses?.map { objectMapper.convertValue(it, CallbackAddress::class.java) })
-            contractOffers(contractOffers?.map { objectMapper.convertValue(it, ContractOffer::class.java) })
-            correlationId(correlationId)
-            counterPartyAddress(counterPartyAddress)
-            counterPartyId(counterPartyId)
-            errorDetail(errorDetail)
-            pending(pending)
-            protocol(protocol)
-            protocolMessages(objectMapper.convertValue(protocolMessages, ProtocolMessages::class.java))
-            state(state)
-            stateCount(stateCount)
-            stateTimestamp?.let { stateTimestamp(it) }
-            traceContext?.let { traceContext(it) }
-            type(EdcContractNegotiation.Type.valueOf(type))
-            updatedAt(updatedAt)
-        }.build()
+        EdcContractNegotiation.Builder
+            .newInstance()
+            .apply {
+                id(id)
+                createdAt(createdAt)
+                contractAgreement?.let { contractAgreement(it.toEdcContractAgreement(objectMapper)) }
+                callbackAddresses(callbackAddresses?.map { objectMapper.convertValue(it, CallbackAddress::class.java) })
+                contractOffers(contractOffers?.map { objectMapper.convertValue(it, ContractOffer::class.java) })
+                correlationId(correlationId)
+                counterPartyAddress(counterPartyAddress)
+                counterPartyId(counterPartyId)
+                errorDetail(errorDetail)
+                pending(pending)
+                protocol(protocol)
+                protocolMessages(objectMapper.convertValue(protocolMessages, ProtocolMessages::class.java))
+                state(state)
+                stateCount(stateCount)
+                stateTimestamp?.let { stateTimestamp(it) }
+                traceContext?.let { traceContext(it) }
+                type(EdcContractNegotiation.Type.valueOf(type))
+                updatedAt(updatedAt)
+            }.build()
 
     companion object {
         const val AGREEMENT_ID = "agreementId"

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/DataPlaneInstance.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/DataPlaneInstance.kt
@@ -47,21 +47,23 @@ data class DataPlaneInstance(
     var url: String? = null,
 ) : Leasable {
     fun toEdcDataPlaneInstance(): EdcDataPlaneInstance =
-        EdcDataPlaneInstance.Builder.newInstance().apply {
-            id(id)
-            allowedSourceTypes(allowedSourceTypes)
-            allowedTransferType(allowedTransferTypes)
-            createdAt(createdAt)
-            errorDetail(errorDetail)
-            lastActive(lastActive)
-            pending(pending)
-            properties(properties)
-            state(state)
-            stateCount(state)
-            stateTimestamp(stateTimestamp)
-            updatedAt(updatedAt)
-            url(url)
-        }.build()
+        EdcDataPlaneInstance.Builder
+            .newInstance()
+            .apply {
+                id(id)
+                allowedSourceTypes(allowedSourceTypes)
+                allowedTransferType(allowedTransferTypes)
+                createdAt(createdAt)
+                errorDetail(errorDetail)
+                lastActive(lastActive)
+                pending(pending)
+                properties(properties)
+                state(state)
+                stateCount(state)
+                stateTimestamp(stateTimestamp)
+                updatedAt(updatedAt)
+                url(url)
+            }.build()
 
     companion object {
         const val ALLOWED_SOURCE_TYPES = "allowedSourceTypes"

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/PolicyDefinition.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/PolicyDefinition.kt
@@ -52,24 +52,28 @@ data class PolicyDefinition(
     var target: String? = null,
 ) {
     fun toEdcPolicyDefinition(objectMapper: ObjectMapper): EdcPolicyDefinition =
-        EdcPolicyDefinition.Builder.newInstance().apply {
-            id(id)
-            createdAt(createdAt)
-            policy(
-                Policy.Builder.newInstance().apply {
-                    assignee(assignee)
-                    assigner(assigner)
-                    duties(duties?.map { objectMapper.convertValue(it, Duty::class.java) })
-                    extensibleProperties(extensibleProperties)
-                    inheritsFrom(inheritsFrom)
-                    permissions(permissions?.map { objectMapper.convertValue(it, Permission::class.java) })
-                    type(PolicyType.valueOf(policyType))
-                    prohibitions(prohibitions?.map { objectMapper.convertValue(it, Prohibition::class.java) })
-                    target(target)
-                }.build(),
-            )
-            privateProperties(privateProperties)
-        }.build()
+        EdcPolicyDefinition.Builder
+            .newInstance()
+            .apply {
+                id(id)
+                createdAt(createdAt)
+                policy(
+                    Policy.Builder
+                        .newInstance()
+                        .apply {
+                            assignee(assignee)
+                            assigner(assigner)
+                            duties(duties?.map { objectMapper.convertValue(it, Duty::class.java) })
+                            extensibleProperties(extensibleProperties)
+                            inheritsFrom(inheritsFrom)
+                            permissions(permissions?.map { objectMapper.convertValue(it, Permission::class.java) })
+                            type(PolicyType.valueOf(policyType))
+                            prohibitions(prohibitions?.map { objectMapper.convertValue(it, Prohibition::class.java) })
+                            target(target)
+                        }.build(),
+                )
+                privateProperties(privateProperties)
+            }.build()
 
     companion object {
         const val ASSIGNEE = "assignee"

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/PolicyMonitor.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/PolicyMonitor.kt
@@ -34,17 +34,19 @@ data class PolicyMonitor(
     var updatedAt: Long = 0L,
 ) : Leasable {
     fun toEdcPolicyMonitor(): PolicyMonitorEntry =
-        PolicyMonitorEntry.Builder.newInstance().apply {
-            id(id)
-            contractId(contractId)
-            createdAt(createdAt)
-            errorDetail(errorDetail)
-            state(state)
-            stateCount(stateCount)
-            stateTimestamp(stateTimestamp)
-            traceContext(traceContext)
-            updatedAt(updatedAt)
-        }.build()
+        PolicyMonitorEntry.Builder
+            .newInstance()
+            .apply {
+                id(id)
+                contractId(contractId)
+                createdAt(createdAt)
+                errorDetail(errorDetail)
+                state(state)
+                stateCount(stateCount)
+                stateTimestamp(stateTimestamp)
+                traceContext(traceContext)
+                updatedAt(updatedAt)
+            }.build()
 
     companion object {
         const val CONTRACT_ID = "contractId"

--- a/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/TransferProcess.kt
+++ b/edc/extensions/control-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/controlplane/ddb/types/TransferProcess.kt
@@ -87,37 +87,51 @@ data class TransferProcess(
     var updatedAt: Long = 0,
 ) : Leasable {
     fun toEdcTransferProcess(objectMapper: ObjectMapper): EdcTransferProcess =
-        EdcTransferProcess.Builder.newInstance().apply {
-            id(id)
-            assetId(assetId)
-            callbackAddresses(callbackAddresses?.map { objectMapper.convertValue(it, CallbackAddress::class.java) })
-            contentDataAddress?.let {
-                contentDataAddress(DataAddress.Builder.newInstance().properties(contentDataAddress).build())
-            }
-            contractId(contractId)
-            correlationId(correlationId)
-            counterPartyAddress(counterPartyAddress)
-            createdAt(createdAt)
-            dataDestination?.let { dataDestination(DataAddress.Builder.newInstance().properties(dataDestination).build()) }
-            dataPlaneId(dataPlaneId)
-            deprovisionedResources(
-                deprovisionedResources?.map { objectMapper.convertValue(it, DeprovisionedResource::class.java) },
-            )
-            errorDetail(errorDetail)
-            pending(pending)
-            privateProperties(privateProperties)
-            protocol(protocol)
-            protocolMessages(objectMapper.convertValue(protocolMessages, ProtocolMessages::class.java))
-            provisionedResourceSet(objectMapper.convertValue(provisionedResourceSet, ProvisionedResourceSet::class.java))
-            resourceManifest(objectMapper.convertValue(resourceManifest, ResourceManifest::class.java))
-            state(state)
-            stateCount(stateCount)
-            stateTimestamp(stateTimestamp)
-            traceContext(traceContext)
-            transferType(transferType)
-            type(EdcTransferProcess.Type.valueOf(type))
-            updatedAt(updatedAt)
-        }.build()
+        EdcTransferProcess.Builder
+            .newInstance()
+            .apply {
+                id(id)
+                assetId(assetId)
+                callbackAddresses(callbackAddresses?.map { objectMapper.convertValue(it, CallbackAddress::class.java) })
+                contentDataAddress?.let {
+                    contentDataAddress(
+                        DataAddress.Builder
+                            .newInstance()
+                            .properties(contentDataAddress)
+                            .build(),
+                    )
+                }
+                contractId(contractId)
+                correlationId(correlationId)
+                counterPartyAddress(counterPartyAddress)
+                createdAt(createdAt)
+                dataDestination?.let {
+                    dataDestination(
+                        DataAddress.Builder
+                            .newInstance()
+                            .properties(dataDestination)
+                            .build(),
+                    )
+                }
+                dataPlaneId(dataPlaneId)
+                deprovisionedResources(
+                    deprovisionedResources?.map { objectMapper.convertValue(it, DeprovisionedResource::class.java) },
+                )
+                errorDetail(errorDetail)
+                pending(pending)
+                privateProperties(privateProperties)
+                protocol(protocol)
+                protocolMessages(objectMapper.convertValue(protocolMessages, ProtocolMessages::class.java))
+                provisionedResourceSet(objectMapper.convertValue(provisionedResourceSet, ProvisionedResourceSet::class.java))
+                resourceManifest(objectMapper.convertValue(resourceManifest, ResourceManifest::class.java))
+                state(state)
+                stateCount(stateCount)
+                stateTimestamp(stateTimestamp)
+                traceContext(traceContext)
+                transferType(transferType)
+                type(EdcTransferProcess.Type.valueOf(type))
+                updatedAt(updatedAt)
+            }.build()
 
     companion object {
         const val ASSET_ID = "assetId"

--- a/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/assets/DdbAssetIndexTest.kt
+++ b/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/assets/DdbAssetIndexTest.kt
@@ -18,14 +18,16 @@ import software.amazon.edc.extensions.controlplane.ddb.types.toDdbAsset
 
 class DdbAssetIndexTest : AssetIndexTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val table = client.table(Asset.TABLE_NAME, TableSchema.fromBean(Asset::class.java)).apply { createTable() }
     private val assetIndex =
         DdbAssetIndex(
             criterionOperatorRegistry =
-                CriterionOperatorRegistryImpl.ofDefaults()
+                CriterionOperatorRegistryImpl
+                    .ofDefaults()
                     .apply { registerPropertyLookup(AssetPropertyLookup()) },
             table = table,
         )

--- a/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/bpn/DdbBpnStoreTest.kt
+++ b/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/bpn/DdbBpnStoreTest.kt
@@ -4,7 +4,7 @@
 package software.amazon.edc.extensions.controlplane.ddb.bpn
 
 import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded
-import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerStore
+import org.eclipse.tractusx.edc.validation.businesspartner.spi.store.BusinessPartnerStore
 import org.eclipse.tractusx.edc.validation.businesspartner.store.BusinessPartnerStoreTestBase
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema

--- a/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/bpn/DdbBpnStoreTest.kt
+++ b/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/bpn/DdbBpnStoreTest.kt
@@ -12,11 +12,13 @@ import software.amazon.edc.extensions.controlplane.ddb.types.BpnGroup
 
 class DdbBpnStoreTest : BusinessPartnerStoreTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val table =
-        client.table(BpnGroup.TABLE_NAME, TableSchema.fromBean(BpnGroup::class.java))
+        client
+            .table(BpnGroup.TABLE_NAME, TableSchema.fromBean(BpnGroup::class.java))
             .apply { createTable() }
 
     private val bpnStore = DdbBpnStore(table)

--- a/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/contracts/DdbContractDefinitionStoreTest.kt
+++ b/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/contracts/DdbContractDefinitionStoreTest.kt
@@ -14,7 +14,8 @@ import software.amazon.edc.extensions.controlplane.ddb.types.ContractDefinition
 
 class DdbContractDefinitionStoreTest : ContractDefinitionStoreTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val contractDefinitionStore =
@@ -22,7 +23,8 @@ class DdbContractDefinitionStoreTest : ContractDefinitionStoreTestBase() {
             criterionOperatorRegistry = CriterionOperatorRegistryImpl.ofDefaults(),
             objectMapper = ObjectMapper(),
             table =
-                client.table(ContractDefinition.TABLE_NAME, TableSchema.fromBean(ContractDefinition::class.java))
+                client
+                    .table(ContractDefinition.TABLE_NAME, TableSchema.fromBean(ContractDefinition::class.java))
                     .apply { createTable() },
         )
 

--- a/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/contracts/DdbContractNegotiationStoreTest.kt
+++ b/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/contracts/DdbContractNegotiationStoreTest.kt
@@ -17,21 +17,25 @@ import java.time.Duration
 
 class DdbContractNegotiationStoreTest : ContractNegotiationStoreTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val contractAgreementTable =
-        client.table(
-            ContractAgreement.TABLE_NAME,
-            TableSchema.fromBean(ContractAgreement::class.java),
-        ).apply { createTable() }
+        client
+            .table(
+                ContractAgreement.TABLE_NAME,
+                TableSchema.fromBean(ContractAgreement::class.java),
+            ).apply { createTable() }
     private val contractNegotiationTable =
-        client.table(
-            ContractNegotiation.TABLE_NAME,
-            TableSchema.fromBean(ContractNegotiation::class.java),
-        ).apply { createTable() }
+        client
+            .table(
+                ContractNegotiation.TABLE_NAME,
+                TableSchema.fromBean(ContractNegotiation::class.java),
+            ).apply { createTable() }
     private val leaseTable =
-        client.table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
+        client
+            .table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
             .apply { createTable() }
 
     private val contractNegotiationStore =

--- a/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/dataplane/DdbDataPlaneInstanceStoreTest.kt
+++ b/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/dataplane/DdbDataPlaneInstanceStoreTest.kt
@@ -15,14 +15,17 @@ import java.time.Duration
 
 class DdbDataPlaneInstanceStoreTest : DataPlaneInstanceStoreTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val leaseTable =
-        client.table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
+        client
+            .table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
             .apply { createTable() }
     private val dataPlaneInstanceTable =
-        client.table(DataPlaneInstance.TABLE_NAME, TableSchema.fromBean(DataPlaneInstance::class.java))
+        client
+            .table(DataPlaneInstance.TABLE_NAME, TableSchema.fromBean(DataPlaneInstance::class.java))
             .apply { createTable() }
 
     private val dataPlaneInstanceStore =

--- a/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/policies/DdbPolicyDefinitionStoreTest.kt
+++ b/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/policies/DdbPolicyDefinitionStoreTest.kt
@@ -14,11 +14,13 @@ import software.amazon.edc.extensions.controlplane.ddb.types.PolicyDefinition
 
 class DdbPolicyDefinitionStoreTest : PolicyDefinitionStoreTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val table =
-        client.table(PolicyDefinition.TABLE_NAME, TableSchema.fromBean(PolicyDefinition::class.java))
+        client
+            .table(PolicyDefinition.TABLE_NAME, TableSchema.fromBean(PolicyDefinition::class.java))
             .apply { createTable() }
 
     private val policyDefinitionStore =

--- a/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/policies/DdbPolicyMonitorStoreTest.kt
+++ b/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/policies/DdbPolicyMonitorStoreTest.kt
@@ -15,11 +15,13 @@ import java.time.Duration
 
 class DdbPolicyMonitorStoreTest : PolicyMonitorStoreTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val leaseTable =
-        client.table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
+        client
+            .table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
             .apply { createTable() }
     private val policyMonitorTable =
         client.table(PolicyMonitor.TABLE_NAME, TableSchema.fromBean(PolicyMonitor::class.java)).apply { createTable() }

--- a/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/transfers/DdbTransferProcessStoreTest.kt
+++ b/edc/extensions/control-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/controlplane/ddb/transfers/DdbTransferProcessStoreTest.kt
@@ -17,14 +17,17 @@ import java.time.Duration
 
 class DdbTransferProcessStoreTest : TransferProcessStoreTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val leaseTable =
-        client.table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
+        client
+            .table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
             .apply { createTable() }
     private val transferProcessTable =
-        client.table(TransferProcess.TABLE_NAME, TableSchema.fromBean(TransferProcess::class.java))
+        client
+            .table(TransferProcess.TABLE_NAME, TableSchema.fromBean(TransferProcess::class.java))
             .apply { createTable() }
 
     private val transferProcessStore =

--- a/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/DataPlaneDdbExtension.kt
+++ b/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/DataPlaneDdbExtension.kt
@@ -12,17 +12,17 @@ import org.eclipse.edc.runtime.metamodel.annotation.Provides
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry
 import org.eclipse.edc.spi.system.ServiceExtension
 import org.eclipse.edc.spi.system.ServiceExtensionContext
-import software.amazon.edc.extensions.dataplane.ddb.accesstokens.DdbAccessTokenDataStore
-import software.amazon.edc.extensions.dataplane.ddb.store.DdbDataPlaneStore
-import software.amazon.edc.extensions.dataplane.ddb.types.AccessToken
-import software.amazon.edc.extensions.dataplane.ddb.types.DataFlow
-import software.amazon.edc.extensions.common.ddb.edr.DdbEdrEntryIndex
-import software.amazon.edc.extensions.common.ddb.types.EdrEntry
-import software.amazon.edc.extensions.common.ddb.types.Lease
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.edc.extensions.common.ddb.edr.DdbEdrEntryIndex
+import software.amazon.edc.extensions.common.ddb.types.EdrEntry
+import software.amazon.edc.extensions.common.ddb.types.Lease
+import software.amazon.edc.extensions.dataplane.ddb.accesstokens.DdbAccessTokenDataStore
+import software.amazon.edc.extensions.dataplane.ddb.store.DdbDataPlaneStore
+import software.amazon.edc.extensions.dataplane.ddb.types.AccessToken
+import software.amazon.edc.extensions.dataplane.ddb.types.DataFlow
 import java.time.Clock
 
 @Provides(
@@ -51,23 +51,26 @@ class DataPlaneDdbExtension : ServiceExtension {
         ddbClient = DynamoDbEnhancedClient.builder().dynamoDbClient(DynamoDbClient.create()).build()
         leaseTable = ddbClient.table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
 
-        accessTokenDataStoreImpl = DdbAccessTokenDataStore(
-            criterionOperatorRegistry,
-            ddbClient.table(AccessToken.TABLE_NAME, TableSchema.fromBean(AccessToken::class.java))
-        )
+        accessTokenDataStoreImpl =
+            DdbAccessTokenDataStore(
+                criterionOperatorRegistry,
+                ddbClient.table(AccessToken.TABLE_NAME, TableSchema.fromBean(AccessToken::class.java)),
+            )
         context.registerService(AccessTokenDataStore::class.java, accessTokenDataStoreImpl)
 
-        dataPlaneStoreImpl = DdbDataPlaneStore(
-            clock = clock,
-            leaseTable = leaseTable,
-            leaseHolder = context.runtimeId,
-            table = ddbClient.table(DataFlow.TABLE_NAME, TableSchema.fromBean(DataFlow::class.java))
-        )
+        dataPlaneStoreImpl =
+            DdbDataPlaneStore(
+                clock = clock,
+                leaseTable = leaseTable,
+                leaseHolder = context.runtimeId,
+                table = ddbClient.table(DataFlow.TABLE_NAME, TableSchema.fromBean(DataFlow::class.java)),
+            )
         context.registerService(DataPlaneStore::class.java, dataPlaneStoreImpl)
 
-        val edrIndex = DdbEdrEntryIndex(
-            ddbClient.table(EdrEntry.TABLE_NAME, TableSchema.fromBean(EdrEntry::class.java))
-        )
+        val edrIndex =
+            DdbEdrEntryIndex(
+                ddbClient.table(EdrEntry.TABLE_NAME, TableSchema.fromBean(EdrEntry::class.java)),
+            )
         context.registerService(EndpointDataReferenceEntryIndex::class.java, edrIndex)
 
         monitor.info("Data Plane DynamoDB Extension initialization complete!")

--- a/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/accesstokens/DdbAccessTokenDataStore.kt
+++ b/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/accesstokens/DdbAccessTokenDataStore.kt
@@ -53,7 +53,8 @@ class DdbAccessTokenDataStore(
         val predicate = querySpec.filterExpression.toPredicate<Any>(criterionOperatorRegistry)
         val comparator = querySpec.getGenericPropertyComparator<Any>()
 
-        return pages.items()
+        return pages
+            .items()
             .asSequence()
             .map { it.toEdcAccessTokenData() }
             .filter { predicate.test(it) }

--- a/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/store/DdbDataPlaneStore.kt
+++ b/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/store/DdbDataPlaneStore.kt
@@ -26,11 +26,12 @@ class DdbDataPlaneStore(
     leaseHolder: String,
     leaseTable: DynamoDbTable<Lease>,
     private val table: DynamoDbTable<DataFlow>,
-) : DataPlaneStore, AbstractLeasableEntityDao(
+) : AbstractLeasableEntityDao(
         clock = clock,
         leaseHolder = leaseHolder,
         leaseTable = leaseTable,
-    ) {
+    ),
+    DataPlaneStore {
     override fun findById(id: String): EdcDataFlow? = getDataFlow(id)?.toEdcDataFlow()
 
     override fun nextNotLeased(
@@ -38,22 +39,24 @@ class DdbDataPlaneStore(
         vararg criteria: Criterion,
     ): MutableList<EdcDataFlow> {
         val querySpec =
-            QuerySpec.Builder.newInstance()
+            QuerySpec.Builder
+                .newInstance()
                 .filter(criteria.toList())
                 .sortField(DataFlow.STATE_TIMESTAMP)
                 .sortOrder(SortOrder.ASC)
                 .limit(max)
                 .build()
         val request = querySpec.toScanRequest()
-        return table.scan(request).items()
+        return table
+            .scan(request)
+            .items()
             .asSequence()
             .filterNot { hasLease(it.id) }
             .sortedWith(querySpec.getGenericPropertyComparator())
             .map {
                 acquireLease(it)
                 it.toEdcDataFlow()
-            }
-            .applyOffsetAndLimit(querySpec)
+            }.applyOffsetAndLimit(querySpec)
             .toMutableList()
     }
 

--- a/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/types/AccessToken.kt
+++ b/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/types/AccessToken.kt
@@ -30,8 +30,14 @@ data class AccessToken(
     fun toEdcAccessTokenData(): AccessTokenData =
         AccessTokenData(
             id,
-            ClaimToken.Builder.newInstance().claims(claimToken).build(),
-            DataAddress.Builder.newInstance().properties(dataAddress).build(),
+            ClaimToken.Builder
+                .newInstance()
+                .claims(claimToken)
+                .build(),
+            DataAddress.Builder
+                .newInstance()
+                .properties(dataAddress)
+                .build(),
             additionalProperties,
         )
 

--- a/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/types/DataFlow.kt
+++ b/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/types/DataFlow.kt
@@ -55,25 +55,41 @@ data class DataFlow(
     var updatedAt: Long = 0L,
 ) : Leasable {
     fun toEdcDataFlow(): EdcDataFlow =
-        EdcDataFlow.Builder.newInstance().apply {
-            id(id)
-            callbackAddress(callbackAddress?.let { URI.create(it) })
-            createdAt(createdAt)
-            destination(destination?.let { DataAddress.Builder.newInstance().properties(it).build() })
-            errorDetail(errorDetail)
-            transferType(
-                transferTypeFlow?.let {
-                    TransferType(transferTypeDestination ?: "", FlowType.valueOf(it), transferTypeResponseChannel)
-                },
-            )
-            properties(properties)
-            source(source?.let { DataAddress.Builder.newInstance().properties(it).build() })
-            state?.let { state(it) }
-            stateCount(stateCount)
-            stateTimestamp(stateTimestamp)
-            traceContext(traceContext)
-            updatedAt(updatedAt)
-        }.build()
+        EdcDataFlow.Builder
+            .newInstance()
+            .apply {
+                id(id)
+                callbackAddress(callbackAddress?.let { URI.create(it) })
+                createdAt(createdAt)
+                destination(
+                    destination?.let {
+                        DataAddress.Builder
+                            .newInstance()
+                            .properties(it)
+                            .build()
+                    },
+                )
+                errorDetail(errorDetail)
+                transferType(
+                    transferTypeFlow?.let {
+                        TransferType(transferTypeDestination ?: "", FlowType.valueOf(it), transferTypeResponseChannel)
+                    },
+                )
+                properties(properties)
+                source(
+                    source?.let {
+                        DataAddress.Builder
+                            .newInstance()
+                            .properties(it)
+                            .build()
+                    },
+                )
+                state?.let { state(it) }
+                stateCount(stateCount)
+                stateTimestamp(stateTimestamp)
+                traceContext(traceContext)
+                updatedAt(updatedAt)
+            }.build()
 
     companion object {
         const val CALLBACK_ADDRESS = "callbackAddress"

--- a/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/types/DataFlow.kt
+++ b/edc/extensions/data-plane/ddb/src/main/kotlin/software/amazon/edc/extensions/dataplane/ddb/types/DataFlow.kt
@@ -5,6 +5,7 @@ package software.amazon.edc.extensions.dataplane.ddb.types
 
 import org.eclipse.edc.spi.types.domain.DataAddress
 import org.eclipse.edc.spi.types.domain.transfer.FlowType
+import org.eclipse.edc.spi.types.domain.transfer.TransferType
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy
@@ -28,8 +29,12 @@ data class DataFlow(
     var destination: Map<String, Any>? = null,
     @get:DynamoDbAttribute(ERROR_DETAIL)
     var errorDetail: String? = null,
-    @get:DynamoDbAttribute(FLOW_TYPE)
-    var flowType: String? = null,
+    @get:DynamoDbAttribute(TRANSFER_TYPE_DESTINATION)
+    var transferTypeDestination: String? = null,
+    @get:DynamoDbAttribute(TRANSFER_TYPE_FLOW)
+    var transferTypeFlow: String? = null,
+    @get:DynamoDbAttribute(TRANSFER_TYPE_RESPONSE_CHANNEL)
+    var transferTypeResponseChannel: String? = null,
     @get:DynamoDbAttribute(LEASE_ID)
     override var leaseId: String? = null,
     @get:DynamoDbAttribute(PROPERTIES)
@@ -56,7 +61,11 @@ data class DataFlow(
             createdAt(createdAt)
             destination(destination?.let { DataAddress.Builder.newInstance().properties(it).build() })
             errorDetail(errorDetail)
-            flowType(flowType?.let { FlowType.valueOf(it) })
+            transferType(
+                transferTypeFlow?.let {
+                    TransferType(transferTypeDestination ?: "", FlowType.valueOf(it), transferTypeResponseChannel)
+                },
+            )
             properties(properties)
             source(source?.let { DataAddress.Builder.newInstance().properties(it).build() })
             state?.let { state(it) }
@@ -71,7 +80,9 @@ data class DataFlow(
         const val CREATED_AT = "createdAt"
         const val DESTINATION = "destination"
         const val ERROR_DETAIL = "errorDetail"
-        const val FLOW_TYPE = "flowType"
+        const val TRANSFER_TYPE_DESTINATION = "transferTypeDestination"
+        const val TRANSFER_TYPE_FLOW = "transferTypeFlow"
+        const val TRANSFER_TYPE_RESPONSE_CHANNEL = "transferTypeResponseChannel"
         const val LEASE_ID = "leaseId"
         const val ID = "id"
         const val PROPERTIES = "properties"
@@ -93,7 +104,9 @@ fun EdcDataFlow.toDdbDataFlow(leaseId: String? = null): DataFlow =
         createdAt = createdAt,
         destination = destination?.properties,
         errorDetail = errorDetail,
-        flowType = flowType?.toString(),
+        transferTypeDestination = transferType?.destinationType(),
+        transferTypeFlow = transferType?.flowType()?.toString(),
+        transferTypeResponseChannel = transferType?.responseChannelType(),
         leaseId = leaseId,
         properties = properties,
         source = source?.properties,

--- a/edc/extensions/data-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/dataplane/ddb/accesstokens/DdbAccessTokenDataStoreTest.kt
+++ b/edc/extensions/data-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/dataplane/ddb/accesstokens/DdbAccessTokenDataStoreTest.kt
@@ -13,11 +13,13 @@ import software.amazon.edc.extensions.dataplane.ddb.types.AccessToken
 
 class DdbAccessTokenDataStoreTest : AccessTokenDataTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val table =
-        client.table(AccessToken.TABLE_NAME, TableSchema.fromBean(AccessToken::class.java))
+        client
+            .table(AccessToken.TABLE_NAME, TableSchema.fromBean(AccessToken::class.java))
             .apply { createTable() }
 
     private val accessTokenIndex =

--- a/edc/extensions/data-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/dataplane/ddb/store/DdbDataPlaneStoreTest.kt
+++ b/edc/extensions/data-plane/ddb/src/test/kotlin/software/amazon/edc/extensions/dataplane/ddb/store/DdbDataPlaneStoreTest.kt
@@ -15,14 +15,17 @@ import java.time.Duration
 
 class DdbDataPlaneStoreTest : DataPlaneStoreTestBase() {
     private val client =
-        DynamoDbEnhancedClient.builder()
+        DynamoDbEnhancedClient
+            .builder()
             .dynamoDbClient(DynamoDBEmbedded.create().dynamoDbClient())
             .build()
     private val dataFlowTable =
-        client.table(DataFlow.TABLE_NAME, TableSchema.fromBean(DataFlow::class.java))
+        client
+            .table(DataFlow.TABLE_NAME, TableSchema.fromBean(DataFlow::class.java))
             .apply { createTable() }
     private val leaseTable =
-        client.table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
+        client
+            .table(Lease.TABLE_NAME, TableSchema.fromBean(Lease::class.java))
             .apply { createTable() }
 
     private val dataPlaneStore =

--- a/edc/gradle/libs.versions.toml
+++ b/edc/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-aws-sdk = "2.31.+"
-edc = "0.7.+"
-edc-aws = "0.7.2"
-junit-jupiter = "5.10.3"
-kotlin = "2.0.+"
-log4j = "2.24.+"
-tx = "0.7.+"
+aws-sdk = "2.42.+"
+edc = "0.11.+"
+edc-aws = "0.11.+"
+junit-jupiter = "5.11.+"
+kotlin = "2.2.+"
+log4j = "2.25.+"
+tx = "0.11.+"
 
 [libraries]
 aws-dynamodb-local = { module = "com.amazonaws:DynamoDBLocal", version = "2.6.+" }
@@ -45,3 +45,4 @@ tx-spi-bpn-validation = { module = "org.eclipse.tractusx.edc:bpn-validation-spi"
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.1.+" }
+shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }

--- a/edc/gradle/libs.versions.toml
+++ b/edc/gradle/libs.versions.toml
@@ -1,9 +1,8 @@
 [versions]
 aws-sdk = "2.42.+"
-edc = "0.11.+"
-edc-aws = "0.11.+"
-junit-jupiter = "5.11.+"
-kotlin = "2.2.+"
+edc = "0.14.0"
+junit-jupiter = "5.14.+"
+kotlin = "2.3.+"
 log4j = "2.25.+"
 tx = "0.11.+"
 
@@ -12,10 +11,10 @@ aws-dynamodb-local = { module = "com.amazonaws:DynamoDBLocal", version = "2.6.+"
 aws-sdk-dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "aws-sdk"}
 aws-sdk-dynamodb-enhanced = { module = "software.amazon.awssdk:dynamodb-enhanced", version.ref = "aws-sdk"}
 edc-controlplane-core = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }
-edc-dpf-awss3-validator = { module = "org.eclipse.edc.aws:validator-data-address-s3", version.ref = "edc-aws" }
+edc-dpf-awss3-validator = { module = "org.eclipse.edc.aws:validator-data-address-s3", version.ref = "edc" }
 edc-lib-query = { module = "org.eclipse.edc:query-lib", version.ref = "edc" }
 edc-lib-store = { module = "org.eclipse.edc:store-lib", version.ref = "edc" }
-edc-provision-aws-s3 = { module = "org.eclipse.edc.aws:provision-aws-s3", version.ref = "edc-aws" }
+edc-provision-aws-s3 = { module = "org.eclipse.edc.aws:provision-aws-s3", version.ref = "edc" }
 edc-spi-asset = { module = "org.eclipse.edc:asset-spi", version.ref = "edc" }
 edc-spi-contract = { module = "org.eclipse.edc:contract-spi", version.ref = "edc" }
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
@@ -27,8 +26,8 @@ edc-spi-store-edr = { module = "org.eclipse.edc:edr-store-spi", version.ref = "e
 edc-spi-transfer = { module = "org.eclipse.edc:transfer-spi", version.ref = "edc" }
 edc-spi-validator = { module = "org.eclipse.edc:validator-spi", version.ref = "edc" }
 edc-transaction-local = { module = "org.eclipse.edc:transaction-local", version.ref = "edc" }
-edc-vault-aws = { module = "org.eclipse.edc.aws:vault-aws", version.ref = "edc-aws" }
-jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version = "2.18.+" }
+edc-vault-aws = { module = "org.eclipse.edc.aws:vault-aws", version.ref = "edc" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version = "2.21.+" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
@@ -44,5 +43,5 @@ tx-spi-bpn-validation = { module = "org.eclipse.tractusx.edc:bpn-validation-spi"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.1.+" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "14.1.+" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }

--- a/kiro-power/POWER.md
+++ b/kiro-power/POWER.md
@@ -10,7 +10,7 @@ author: "AWS"
 
 ## Overview
 
-This power helps you deploy and operate a production-ready Dataspace Connector for Catena-X on AWS. It combines an AWS CDK deployment blueprint with 14 MCP tools for interacting with the Eclipse Dataspace Components (EDC) Management API.
+This power helps you deploy and operate a production-ready Dataspace Connector for Catena-X on AWS. It combines an AWS CDK deployment blueprint with 15 MCP tools for interacting with the Eclipse Dataspace Components (EDC) Management API.
 
 The connector uses Tractus-X EDC with AWS-native integrations: Amazon DynamoDB for control plane persistence, AWS Secrets Manager for credentials, Amazon S3 for data transfer, and Amazon API Gateway with IAM authorization for secure API access.
 
@@ -23,7 +23,7 @@ With this power, you can go from zero to a fully deployed connector with validat
 
 ## Available MCP Tools
 
-This power provides 14 tools covering the full EDC Management API workflow:
+This power provides 15 tools covering the full EDC Management API workflow:
 
 ### Provider-side tools (create data offerings)
 - `create_asset` — Create a new asset with data address
@@ -33,11 +33,12 @@ This power provides 14 tools covering the full EDC Management API workflow:
 ### Consumer-side tools (discover and consume data)
 - `request_catalog` — Request the catalog from another connector to discover available datasets
 - `initiate_contract_negotiation` — Start a contract negotiation (passes full policy from catalog)
-- `get_negotiation_state` — Poll the state of a contract negotiation
+- `get_contract_negotiation` — Get the full contract negotiation object including state, contractAgreementId, and errorDetail
 - `get_contract_agreement` — Retrieve a finalized contract agreement
 - `initiate_transfer` — Start a data transfer using a contract agreement
-- `get_transfer_state` — Poll the state of a transfer process
+- `get_transfer_process` — Get the full transfer process object including state, correlationId, and errorDetail
 - `get_edr_data_address` — Get the endpoint data reference (EDR) for an active transfer
+- `initiate_edr_negotiation` — Combined negotiation + transfer in one call (shortcut for the full consumer flow)
 
 ### Query tools
 - `query_assets` — List/search assets with filtering and pagination
@@ -86,7 +87,7 @@ Once deployed, activate the **validate-data-exchange** steering file to validate
 ### Discover datasets from another connector
 ```python
 request_catalog(
-    counter_party_address="https://provider.example.com/dsp",
+    counter_party_address="https://provider.example.com/protocol",
     counter_party_id="BPNL000000000001"
 )
 ```
@@ -95,7 +96,7 @@ request_catalog(
 ```python
 # 1. Negotiate a contract (pass full policy from catalog offer)
 initiate_contract_negotiation(
-    counter_party_address="https://provider.example.com/dsp",
+    counter_party_address="https://provider.example.com/protocol",
     offer_id="<offer-id-from-catalog>",
     asset_id="<asset-id>",
     assigner="BPNL000000000001",
@@ -104,15 +105,15 @@ initiate_contract_negotiation(
     obligation=[]
 )
 
-# 2. Poll until FINALIZED
-get_negotiation_state(negotiation_id="<negotiation-id>")
+# 2. Poll until FINALIZED — returns full object with contractAgreementId
+get_contract_negotiation(negotiation_id="<negotiation-id>")
 
-# 3. Retrieve agreement
+# 3. Extract contractAgreementId from the response above, then retrieve agreement
 get_contract_agreement(agreement_id="<agreement-id>")
 
 # 4. Start transfer
 initiate_transfer(
-    counter_party_address="https://provider.example.com/dsp",
+    counter_party_address="https://provider.example.com/protocol",
     contract_id="<agreement-id>",
     transfer_type="HttpData-PULL"
 )
@@ -121,30 +122,80 @@ initiate_transfer(
 get_edr_data_address(transfer_process_id="<transfer-id>")
 ```
 
+### Alternative: Combined negotiation + transfer (shortcut)
+```python
+# Single call that handles negotiation and transfer automatically
+initiate_edr_negotiation(
+    counter_party_address="https://provider.example.com/protocol",
+    offer_id="<offer-id-from-catalog>",
+    asset_id="<asset-id>",
+    assigner="BPNL000000000001",
+    permission=[{"odrl:action": {"@id": "odrl:use"}}],
+    prohibition=[],
+    obligation=[]
+)
+
+# Poll negotiation until FINALIZED to get the contractAgreementId
+negotiation = get_contract_negotiation(negotiation_id="<negotiation-id>")
+
+# Find the transfer process created by the EDR negotiation
+transfers = query_transfer_processes(filter_expression=[{
+    "operandLeft": "contractId",
+    "operator": "=",
+    "operandRight": "<contractAgreementId-from-negotiation>"
+}])
+
+# Once the transfer reaches STARTED, get the EDR
+get_edr_data_address(transfer_process_id="<transfer-id-from-query>")
+```
+
 ### Create a data offering (provider side)
 ```python
-# 1. Policy
+# 1. Access policy (controls catalog visibility)
 create_policy_definition(
-    policy_id="allow-all",
+    policy_id="my-access-policy",
     policy={
-        "@context": "http://www.w3.org/ns/odrl.jsonld",
         "@type": "Set",
-        "permission": [{"action": "use"}]
+        "permission": [{
+            "action": "access",
+            "constraint": {
+                "leftOperand": "Membership",
+                "operator": "eq",
+                "rightOperand": "active"
+            }
+        }]
     }
 )
 
-# 2. Asset
+# 2. Usage policy (controls contract negotiation — requires FrameworkAgreement + UsagePurpose)
+create_policy_definition(
+    policy_id="my-usage-policy",
+    policy={
+        "@type": "Set",
+        "permission": [{
+            "action": "use",
+            "constraint": [{
+                "and": [
+                    {"leftOperand": "FrameworkAgreement", "operator": "eq", "rightOperand": "DataExchangeGovernance:1.0"},
+                    {"leftOperand": "UsagePurpose", "operator": "isAnyOf", "rightOperand": "cx.core.industrycore:1"}
+                ]
+            }]
+        }]
+    }
+)
+
+# 3. Asset
 create_asset(
     asset_id="my-dataset",
     properties={"name": "Sample Dataset", "contentType": "application/json"},
     data_address={"type": "HttpData", "baseUrl": "https://example.com/api/data"}
 )
 
-# 3. Contract definition
+# 4. Contract definition (links asset to both policies)
 create_contract_definition(
     contract_definition_id="my-contract-def",
-    access_policy_id="allow-all",
-    contract_policy_id="allow-all",
+    access_policy_id="my-access-policy",
+    contract_policy_id="my-usage-policy",
     assets_selector=[{
         "operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
         "operator": "=",
@@ -181,7 +232,8 @@ The MCP server refreshes AWS credentials on every request, so temporary credenti
 | `IATP_ID` | Your organization's DID |
 | `OAUTH_CLIENT_ID` | Technical user OAuth client ID |
 | `OAUTH_TOKEN_URL` | OAuth token endpoint URL |
-| `PARTICIPANT_ID` | Your BPNL number |
+| `PARTICIPANT_ID` | Your organization's DID (same as `IATP_ID`) |
+| `PARTICIPANT_BPN` | Your BPNL number |
 | `TRUSTED_ISSUER_ID` | Trusted issuer DID (Cofinity-X) |
 
 ### environments.ts — AWS Resource Settings

--- a/kiro-power/steering/deploy-connector.md
+++ b/kiro-power/steering/deploy-connector.md
@@ -22,7 +22,7 @@ If the container runtime is Finch (not Docker), perform these additional checks:
 echo $CDK_DOCKER
 ```
 
-- If it's already set to `finch`, no action needed.
+- If it's already set and contains `finch` (e.g., `finch` or `/path/to/finch`), no action needed.
 - If it's empty, uncomment `export CDK_DOCKER=finch` in `deploy.sh`.
 
 2. Check whether the Finch VM is running:
@@ -70,8 +70,8 @@ Use the ARN from THIS output (not the earlier unqualified check) for IAM princip
 Ask the user:
 > "Which AWS region would you like to deploy to? The default is `eu-central-1`."
 
-If the user picks a different region, update `deploy.sh`:
-- Change `export AWS_REGION=eu-central-1` to their chosen region
+If the user picks a different region, they will need to set `AWS_REGION` before running `deploy.sh`:
+- The script defaults to `eu-central-1` but respects the `AWS_REGION` environment variable if set
 
 Store the chosen region — it will be needed for MCP configuration later.
 
@@ -86,7 +86,7 @@ First, check whether the `edcIam` object already has values populated (i.e., fie
 
 If the user wants to keep existing values, skip to Phase 4.
 
-In a fresh clone, the `edcIam` object has 7 fields all set to empty strings (`""`). These must be populated with values from the Cofinity-X Portal:
+In a fresh clone, the `edcIam` object has 8 fields all set to empty strings (`""`). These must be populated with values from the Cofinity-X Portal:
 
 | Field | What to ask the user |
 |-------|---------------------|
@@ -95,7 +95,8 @@ In a fresh clone, the `edcIam` object has 7 fields all set to empty strings (`""
 | `IATP_ID` | "What is your organization's DID?" (starts with `did:web:`) |
 | `OAUTH_CLIENT_ID` | "What is your technical user's OAuth client ID?" |
 | `OAUTH_TOKEN_URL` | "What is your OAuth token endpoint URL?" |
-| `PARTICIPANT_ID` | "What is your BPNL number?" (e.g., `BPNL000000000001`) |
+| `PARTICIPANT_ID` | "What is your organization's DID?" (same value as `IATP_ID` — used as the DSP protocol identity) |
+| `PARTICIPANT_BPN` | "What is your BPNL number?" (e.g., `BPNL000000000001`) |
 | `TRUSTED_ISSUER_ID` | "What is the trusted issuer DID?" (starts with `did:web:`) |
 
 Collect all values from the user, then update the `edcIam` object in `cdk/lib/config/environments.ts` with the provided values.
@@ -159,13 +160,18 @@ Only modify if the user explicitly asks.
 Tell the user:
 > "Configuration is complete. I'll now run the deployment. This will build the EDC Java artifacts, install CDK dependencies, bootstrap your AWS account (if needed), and deploy the CloudFormation stack. This typically takes 10-15 minutes."
 
-IMPORTANT: `deploy.sh` is a long-running process (10-15+ minutes). Start it as a background process so you can monitor progress without blocking. If a specific AWS profile is needed, prepend it to the command:
+IMPORTANT: `deploy.sh` is a long-running process (10-15+ minutes). Start it as a background process so you can monitor progress without blocking. The script reads `AWS_PROFILE` and `AWS_REGION` from the environment (with `eu-central-1` as the default region). Set the profile before running:
 
 ```bash
-AWS_PROFILE=<deployment-profile> ./deploy.sh
+export AWS_PROFILE=<deployment-profile>
+./deploy.sh
 ```
 
-If `$AWS_PROFILE` is already exported in the user's shell, you can run `./deploy.sh` directly.
+If a different region was chosen in Phase 2, also set it:
+
+```bash
+export AWS_REGION=<chosen-region>
+```
 
 Poll the process output at 30-second intervals to monitor progress. Do NOT poll more frequently — rapid polling generates excessive tool calls and can cause the agent to stall or hit context limits on long deployments. The deployment has these major phases:
 1. Gradle build (~30s) — look for `BUILD SUCCESSFUL`
@@ -179,10 +185,10 @@ This script:
 3. Bootstraps the AWS account (`cdk bootstrap`)
 4. Deploys the stack (`cdk deploy`)
 
-After deployment succeeds, the CDK output will contain the API endpoints. Extract and store these values:
-- `EdcApiManagementApiEndpoint` — needed for MCP configuration
-- `EdcApiDspApiEndpoint` — the DSP endpoint for catalog requests
-- `EdcApiDataPlaneApiEndpoint` — data plane endpoint
+After deployment succeeds, the CDK output will contain the API endpoints. Extract and store these values (output keys have CDK-generated hash suffixes — match by prefix):
+- Key starting with `EdcApiManagementApiEndpoint` — needed for MCP configuration
+- Key starting with `EdcApiDspApiEndpoint` — the DSP endpoint for catalog requests
+- Key starting with `EdcApiDataPlaneApiEndpoint` — data plane endpoint
 - `EdcOauthClientSecretArn` — Secrets Manager ARN for the OAuth secret
 
 ---
@@ -262,12 +268,12 @@ Then validate the DSP endpoint by requesting the connector's own catalog:
 ```
 request_catalog(
     counter_party_address="<EdcApiDspApiEndpoint from CDK output>",
-    counter_party_id="<PARTICIPANT_ID from Phase 3>"
+    counter_party_id="<PARTICIPANT_BPN from Phase 3>"
 )
 ```
 
 If both calls succeed, tell the user:
-> "Your Dataspace Connector is deployed and the MCP tools are connected. You can now create data offerings, browse catalogs, negotiate contracts, and transfer data using the 14 available tools."
+> "Your Dataspace Connector is deployed and the MCP tools are connected. You can now create data offerings, browse catalogs, negotiate contracts, and transfer data using the 15 available tools."
 
 If either call fails, check:
 - AWS credentials are valid and not expired

--- a/kiro-power/steering/validate-data-exchange.md
+++ b/kiro-power/steering/validate-data-exchange.md
@@ -26,7 +26,7 @@ aws logs describe-log-groups --region <region> --output json \
     --query 'logGroups[?contains(logGroupName, `ControlPlaneLogGroup`) || contains(logGroupName, `DataPlaneLogGroup`)].logGroupName'
 ```
 
-Store both log group names — they are needed for diagnosing any issues in Phase 7.
+Store both log group names — they are needed for diagnosing any issues in Phase 8.
 
 ---
 
@@ -52,28 +52,63 @@ Otherwise, proceed to the relevant phase based on their answer.
 
 Walk the user through creating a complete data offering. Ask for details or use sensible defaults.
 
-### Step 3.1: Define a Policy
+### Step 3.1: Define Policies
 
-Ask the user:
+Tractus-X EDC requires separate access and usage policies with Catena-X-compliant constraints. Ask the user:
 > "What access policy should govern your data? Common options:
-> - **Open access** — Anyone can use the data (good for testing)
+> - **Open access** — Any Catena-X member can see and use the data (good for testing)
 > - **BPN-restricted** — Only specific business partners can access it
 >
 > For validation, open access is simplest. Want to go with that?"
 
-For open access:
+For open access, create two policies — one for access (who can see the offer) and one for usage (who can negotiate a contract):
+
+**Access policy** (controls catalog visibility):
 ```python
 create_policy_definition(
-    policy_id="<user-chosen-id-or-default>",
+    policy_id="<user-chosen-id-or-default>-access",
     policy={
-        "@context": "http://www.w3.org/ns/odrl.jsonld",
         "@type": "Set",
-        "permission": [{"action": "use"}]
+        "permission": [{
+            "action": "access",
+            "constraint": {
+                "leftOperand": "Membership",
+                "operator": "eq",
+                "rightOperand": "active"
+            }
+        }]
     }
 )
 ```
 
-For BPN-restricted access, ask for the allowed BPNLs and construct an appropriate ODRL constraint.
+**Usage/contract policy** (controls negotiation — requires FrameworkAgreement + UsagePurpose):
+```python
+create_policy_definition(
+    policy_id="<user-chosen-id-or-default>-usage",
+    policy={
+        "@type": "Set",
+        "permission": [{
+            "action": "use",
+            "constraint": [{
+                "and": [
+                    {
+                        "leftOperand": "FrameworkAgreement",
+                        "operator": "eq",
+                        "rightOperand": "DataExchangeGovernance:1.0"
+                    },
+                    {
+                        "leftOperand": "UsagePurpose",
+                        "operator": "isAnyOf",
+                        "rightOperand": "cx.core.industrycore:1"
+                    }
+                ]
+            }]
+        }]
+    }
+)
+```
+
+For BPN-restricted access, replace the access policy's `Membership` constraint with a `BusinessPartnerNumber` constraint targeting the allowed BPNL.
 
 ### Step 3.2: Create an Asset
 
@@ -97,7 +132,7 @@ create_asset(
         "type": "AmazonS3",
         "region": "<aws-region>",
         "bucketName": "<bucket-name>",
-        "keyName": "<object-key>"
+        "objectName": "<object-key>"
     }
 )
 ```
@@ -128,13 +163,13 @@ create_asset(
 
 ### Step 3.3: Create a Contract Definition
 
-Link the asset to the policy:
+Link the asset to both policies:
 
 ```python
 create_contract_definition(
     contract_definition_id="<user-chosen-id>",
-    access_policy_id="<policy-id-from-step-3.1>",
-    contract_policy_id="<policy-id-from-step-3.1>",
+    access_policy_id="<access-policy-id-from-step-3.1>",
+    contract_policy_id="<usage-policy-id-from-step-3.1>",
     assets_selector=[{
         "operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
         "operator": "=",
@@ -153,7 +188,7 @@ After creation, confirm:
 ### Step 4.1: Browse the Catalog
 
 Ask the user:
-> "What's the DSP endpoint of the provider connector you want to browse? (e.g., `https://<api-id>.execute-api.<region>.amazonaws.com/dsp`)
+> "What's the DSP endpoint of the provider connector you want to browse? (e.g., `https://<api-id>.execute-api.<region>.amazonaws.com/protocol`)
 > And what's their participant ID (BPNL)?"
 
 ```python
@@ -167,6 +202,8 @@ Help the user interpret the catalog response:
 - Each `dcat:dataset` entry is an available asset
 - The `odrl:hasPolicy` contains the offer details needed for negotiation
 - Point out the offer ID (`@id` of the policy), asset ID, and the permission/prohibition/obligation arrays
+
+NOTE: For a simpler flow, `initiate_edr_negotiation` can replace the separate negotiation + transfer steps (Steps 4.2–4.5) with a single call. However, the step-by-step flow below gives more control and visibility.
 
 ### Step 4.2: Negotiate a Contract
 
@@ -190,26 +227,16 @@ IMPORTANT: The `permission`, `prohibition`, and `obligation` must be passed thro
 
 Poll the negotiation state:
 ```python
-get_negotiation_state(negotiation_id="<negotiation-id>")
+get_contract_negotiation(negotiation_id="<negotiation-id>")
 ```
 
 Expected state progression: `REQUESTED` → `AGREED` → `VERIFIED` → `FINALIZED`
 
-If the state is `TERMINATED`, check the error. Common causes:
+If the state is `TERMINATED`, check the `errorDetail` field in the response. Common causes:
 - Policy mismatch (didn't pass full policy from catalog)
 - Provider-side policy evaluation failure (BPN not allowed)
 
-Once `FINALIZED`, retrieve the full negotiation details to get the `contractAgreementId`. The `get_negotiation_state` call only returns the state — you need to query the negotiation to get the agreement ID:
-
-```python
-query_contract_negotiations(filter_expression=[{
-    "operandLeft": "id",
-    "operator": "=",
-    "operandRight": "<negotiation-id>"
-}])
-```
-
-Extract the `contractAgreementId` field from the response.
+Once `FINALIZED`, extract the `contractAgreementId` directly from the `get_contract_negotiation` response — it returns the full negotiation object.
 
 ### Step 4.4: Retrieve the Agreement
 
@@ -233,7 +260,7 @@ For `HttpData-PULL`, the MCP server automatically sets the data destination to `
 
 Poll until the transfer reaches `STARTED`:
 ```python
-get_transfer_state(transfer_process_id="<transfer-id>")
+get_transfer_process(transfer_process_id="<transfer-id>")
 ```
 
 If the transfer state is `TERMINATED` instead of progressing to `STARTED`, do NOT retry blindly. Follow the troubleshooting procedure in Phase 8 to diagnose the root cause.
@@ -274,11 +301,12 @@ aws cloudformation describe-stacks --stack-name DataspaceConnectorStack --region
     --query 'Stacks[0].Outputs' --output json
 ```
 
-Extract:
-- `EdcDataPlaneBucketName` → S3 bucket name
-- `EdcApiDspApiEndpoint` → DSP endpoint URL
+Extract (the output keys have CDK-generated hash suffixes — match by prefix):
+- Key starting with `EdcDataPlaneBucketName` → S3 bucket name
+- Key starting with `EdcApiDspApiEndpoint` → DSP endpoint URL
+- Key starting with `EdcApiManagementApiEndpoint` → Management API URL (for reference)
 
-Read the `PARTICIPANT_ID` from `cdk/lib/config/environments.ts` (the `edc.participant.id` field in the `edcIam` object) for the BPNL.
+Read the `PARTICIPANT_BPN` from `cdk/lib/config/environments.ts` (the `tractusx.edc.participant.bpn` field in the `edcIam` object) for the connector's BPNL. Use this as the `counter_party_id` for catalog requests and as the `assigner` for contract negotiations.
 
 If the user already has these values from a prior deployment, use them directly.
 
@@ -301,16 +329,49 @@ aws s3 ls "s3://<bucket-name>/test/sample-data.json" --region <region> --profile
 
 ### Step 5.3: Create the S3 Test Offering
 
-Create a policy, asset, and contract definition for the test data:
+Create an access policy, usage policy, asset, and contract definition for the test data:
 
-**Policy:**
+**Access policy** (Membership check):
 ```python
 create_policy_definition(
-    policy_id="test-s3-policy",
+    policy_id="test-s3-access-policy",
     policy={
-        "@context": "http://www.w3.org/ns/odrl.jsonld",
         "@type": "Set",
-        "permission": [{"action": "use"}]
+        "permission": [{
+            "action": "access",
+            "constraint": {
+                "leftOperand": "Membership",
+                "operator": "eq",
+                "rightOperand": "active"
+            }
+        }]
+    }
+)
+```
+
+**Usage policy** (FrameworkAgreement + UsagePurpose):
+```python
+create_policy_definition(
+    policy_id="test-s3-usage-policy",
+    policy={
+        "@type": "Set",
+        "permission": [{
+            "action": "use",
+            "constraint": [{
+                "and": [
+                    {
+                        "leftOperand": "FrameworkAgreement",
+                        "operator": "eq",
+                        "rightOperand": "DataExchangeGovernance:1.0"
+                    },
+                    {
+                        "leftOperand": "UsagePurpose",
+                        "operator": "isAnyOf",
+                        "rightOperand": "cx.core.industrycore:1"
+                    }
+                ]
+            }]
+        }]
     }
 )
 ```
@@ -328,17 +389,17 @@ create_asset(
         "type": "AmazonS3",
         "region": "<region>",
         "bucketName": "<bucket-name>",
-        "keyName": "test/sample-data.json"
+        "objectName": "test/sample-data.json"
     }
 )
 ```
 
-**Contract definition:**
+**Contract definition** (links asset to both policies):
 ```python
 create_contract_definition(
     contract_definition_id="test-s3-contract-def",
-    access_policy_id="test-s3-policy",
-    contract_policy_id="test-s3-policy",
+    access_policy_id="test-s3-access-policy",
+    contract_policy_id="test-s3-usage-policy",
     assets_selector=[{
         "operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
         "operator": "=",
@@ -356,7 +417,7 @@ request_catalog(
 )
 ```
 
-Locate the `test-s3-asset` entry in the catalog response and extract the offer details.
+Locate the `test-s3-asset` entry in the catalog response and extract the offer details. Note that the `dspace:participantId` in the catalog response is the BPNL, and the `assigner` in the offer also uses the BPNL — use this value for `counter_party_id` and `assigner` in subsequent steps.
 
 ### Step 5.5: Complete the Consumer Flow
 
@@ -429,17 +490,13 @@ When any EDC operation reaches an unexpected state (e.g., transfer `TERMINATED` 
 
 ### Step 8.1: Query the Failed Process for Error Details
 
-For a failed transfer, query the provider-side transfer process. The consumer transfer has a `correlationId` that maps to the provider's transfer process ID:
+For a failed transfer, first get the full transfer process object which includes `errorDetail` and `correlationId`:
 
 ```python
-query_transfer_processes(filter_expression=[{
-    "operandLeft": "id",
-    "operator": "=",
-    "operandRight": "<consumer-transfer-id>"
-}])
+get_transfer_process(transfer_process_id="<consumer-transfer-id>")
 ```
 
-Extract the `correlationId`, then query the provider side:
+Extract the `correlationId` from the response, then query the provider-side transfer process:
 
 ```python
 query_transfer_processes(filter_expression=[{
@@ -451,14 +508,12 @@ query_transfer_processes(filter_expression=[{
 
 The provider-side response contains the `errorDetail` field with the actual error message. The consumer side typically does not include error details.
 
-For a failed negotiation, query similarly:
+For a failed negotiation, get the full negotiation object directly:
 ```python
-query_contract_negotiations(filter_expression=[{
-    "operandLeft": "id",
-    "operator": "=",
-    "operandRight": "<negotiation-id>"
-}])
+get_contract_negotiation(negotiation_id="<negotiation-id>")
 ```
+
+The response includes the `errorDetail` field when the negotiation is `TERMINATED`.
 
 ### Step 8.2: Discover CloudWatch Log Groups
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server for interacting with the Eclipse Dataspace
 
 ## Features
 
-This MCP server provides 14 tools covering the full EDC Management API workflow:
+This MCP server provides 15 tools covering the full EDC Management API workflow:
 
 ### Provider-side tools
 - **create_asset** - Create a new asset with data address
@@ -14,11 +14,12 @@ This MCP server provides 14 tools covering the full EDC Management API workflow:
 ### Consumer-side tools
 - **request_catalog** - Request the catalog from another EDC connector to discover available datasets
 - **initiate_contract_negotiation** - Start a contract negotiation with a provider (passes full policy from catalog)
-- **get_negotiation_state** - Poll the state of a contract negotiation
+- **get_contract_negotiation** - Get the full contract negotiation object including state and agreement ID
 - **get_contract_agreement** - Retrieve a finalized contract agreement
 - **initiate_transfer** - Start a data transfer using a contract agreement
-- **get_transfer_state** - Poll the state of a transfer process
+- **get_transfer_process** - Get the full transfer process object including state and error details
 - **get_edr_data_address** - Get the endpoint data reference (EDR) for an active transfer
+- **initiate_edr_negotiation** - Combined negotiation + transfer in one call (shortcut for the full consumer flow)
 
 ### Query tools
 - **query_assets** - List/search assets with filtering and pagination
@@ -126,7 +127,7 @@ Add to your `.kiro/settings/mcp.json`:
 ```python
 # 1. Discover available datasets from a provider
 catalog = request_catalog(
-    counter_party_address="https://provider.example.com/dsp",
+    counter_party_address="https://provider.example.com/protocol",
     counter_party_id="BPNL000000000001"
 )
 
@@ -134,7 +135,7 @@ catalog = request_catalog(
 # The permission/prohibition/obligation must be passed through exactly from the catalog offer
 offer = catalog["dcat:dataset"][0]["odrl:hasPolicy"]
 negotiation = initiate_contract_negotiation(
-    counter_party_address="https://provider.example.com/dsp",
+    counter_party_address="https://provider.example.com/protocol",
     offer_id=offer["@id"],
     asset_id="dataset-id",
     assigner="BPNL000000000001",
@@ -144,20 +145,20 @@ negotiation = initiate_contract_negotiation(
 )
 
 # 3. Poll until negotiation is finalized
-state = get_negotiation_state(negotiation_id=negotiation["@id"])
+state = get_contract_negotiation(negotiation_id=negotiation["@id"])
 
 # 4. Retrieve the contract agreement (get agreement ID from negotiation query)
 agreement = get_contract_agreement(agreement_id="<agreement-id>")
 
 # 5. Initiate a data transfer
 transfer = initiate_transfer(
-    counter_party_address="https://provider.example.com/dsp",
+    counter_party_address="https://provider.example.com/protocol",
     contract_id=agreement["@id"],
     transfer_type="HttpData-PULL"
 )
 
 # 6. Poll until transfer is started
-state = get_transfer_state(transfer_process_id=transfer["@id"])
+state = get_transfer_process(transfer_process_id=transfer["@id"])
 
 # 7. Get the endpoint data reference with access token
 edr = get_edr_data_address(transfer_process_id=transfer["@id"])
@@ -166,17 +167,40 @@ edr = get_edr_data_address(transfer_process_id=transfer["@id"])
 ### Create a data offering (provider side)
 
 ```python
-# 1. Create a policy
+# 1. Create an access policy (controls catalog visibility)
 create_policy_definition(
-    policy_id="allow-all",
+    policy_id="my-access-policy",
     policy={
-        "@context": "http://www.w3.org/ns/odrl.jsonld",
         "@type": "Set",
-        "permission": [{"action": "use"}]
+        "permission": [{
+            "action": "access",
+            "constraint": {
+                "leftOperand": "Membership",
+                "operator": "eq",
+                "rightOperand": "active"
+            }
+        }]
     }
 )
 
-# 2. Create an asset
+# 2. Create a usage policy (controls contract negotiation)
+create_policy_definition(
+    policy_id="my-usage-policy",
+    policy={
+        "@type": "Set",
+        "permission": [{
+            "action": "use",
+            "constraint": [{
+                "and": [
+                    {"leftOperand": "FrameworkAgreement", "operator": "eq", "rightOperand": "DataExchangeGovernance:1.0"},
+                    {"leftOperand": "UsagePurpose", "operator": "isAnyOf", "rightOperand": "cx.core.industrycore:1"}
+                ]
+            }]
+        }]
+    }
+)
+
+# 3. Create an asset
 create_asset(
     asset_id="my-dataset",
     properties={
@@ -190,11 +214,11 @@ create_asset(
     }
 )
 
-# 3. Create contract definition linking asset to policy
+# 4. Create contract definition linking asset to both policies
 create_contract_definition(
     contract_definition_id="my-contract-def",
-    access_policy_id="allow-all",
-    contract_policy_id="allow-all",
+    access_policy_id="my-access-policy",
+    contract_policy_id="my-usage-policy",
     assets_selector=[{
         "operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
         "operator": "=",

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -13,11 +13,12 @@ Provider-side tools:
 Consumer-side tools:
 - request_catalog: Request EDC connector catalog from a counterparty
 - initiate_contract_negotiation: Start a contract negotiation with a provider
-- get_negotiation_state: Poll the state of a contract negotiation
+- get_contract_negotiation: Get the full contract negotiation object
 - get_contract_agreement: Retrieve a finalized contract agreement
 - initiate_transfer: Start a data transfer using a contract agreement
-- get_transfer_state: Poll the state of a transfer process
+- get_transfer_process: Get the full transfer process object
 - get_edr_data_address: Get the endpoint data reference for an active transfer
+- initiate_edr_negotiation: Combined negotiation + transfer in one call
 
 Query tools:
 - query_assets: List/search assets
@@ -39,7 +40,7 @@ from mcp.server.fastmcp import FastMCP
 mcp = FastMCP("dataspace-connector")
 
 # Configuration
-EDC_MANAGEMENT_URL = os.getenv("EDC_MANAGEMENT_URL", "http://localhost:8080/management")
+EDC_MANAGEMENT_URL = os.getenv("EDC_MANAGEMENT_URL", "http://localhost:8080/management").rstrip("/")
 EDC_API_KEY = os.getenv("EDC_API_KEY", "")
 USE_AWS_IAM = os.getenv("EDC_USE_AWS_IAM", "false").lower() == "true"
 AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
@@ -138,12 +139,15 @@ async def create_asset(
         )
     """
     payload = {
-        "@context": {"@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
+        "@context": {
+            "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+            "dct": "http://purl.org/dc/terms/",
+        },
         "@id": asset_id,
-        "@type": "https://w3id.org/edc/v0.0.1/ns/Asset",
+        "@type": "Asset",
         "properties": properties,
         "dataAddress": {
-            "@type": "https://w3id.org/edc/v0.0.1/ns/DataAddress",
+            "@type": "DataAddress",
             **data_address,
         },
     }
@@ -173,21 +177,29 @@ async def create_policy_definition(
 
     Example:
         create_policy_definition(
-            policy_id="allow-all-policy",
+            policy_id="usage-policy",
             policy={
-                "@context": "http://www.w3.org/ns/odrl.jsonld",
                 "@type": "Set",
                 "permission": [{
                     "action": "use",
-                    "target": "my-dataset-1"
+                    "constraint": [{
+                        "and": [
+                            {"leftOperand": "FrameworkAgreement", "operator": "eq", "rightOperand": "DataExchangeGovernance:1.0"},
+                            {"leftOperand": "UsagePurpose", "operator": "isAnyOf", "rightOperand": "cx.core.industrycore:1"}
+                        ]
+                    }]
                 }]
             }
         )
     """
     payload = {
-        "@context": {"@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
+        "@context": [
+            "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+            "https://w3id.org/catenax/2025/9/policy/context.jsonld",
+            {"@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
+        ],
         "@id": policy_id,
-        "@type": "https://w3id.org/edc/v0.0.1/ns/PolicyDefinition",
+        "@type": "PolicyDefinition",
         "policy": policy,
     }
     return await _api_request("POST", "/v3/policydefinitions", payload)
@@ -230,7 +242,7 @@ async def create_contract_definition(
     payload = {
         "@context": {"@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
         "@id": contract_definition_id,
-        "@type": "https://w3id.org/edc/v0.0.1/ns/ContractDefinition",
+        "@type": "ContractDefinition",
         "accessPolicyId": access_policy_id,
         "contractPolicyId": contract_policy_id,
         "assetsSelector": assets_selector,
@@ -267,8 +279,8 @@ async def request_catalog(
         )
     """
     payload = {
-        "@context": {"@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
-        "@type": "https://w3id.org/edc/v0.0.1/ns/CatalogRequest",
+        "@context": [{"@vocab": "https://w3id.org/edc/v0.0.1/ns/"}],
+        "@type": "CatalogRequest",
         "counterPartyAddress": counter_party_address,
         "counterPartyId": counter_party_id,
         "protocol": protocol,
@@ -298,7 +310,7 @@ async def initiate_contract_negotiation(
     Initiate a contract negotiation with a provider connector.
 
     Starts an asynchronous negotiation for a specific offer obtained from the catalog.
-    Poll get_negotiation_state to track progress.
+    Poll get_contract_negotiation to track progress.
 
     Args:
         counter_party_address: The DSP endpoint URL of the provider connector
@@ -326,7 +338,6 @@ async def initiate_contract_negotiation(
         )
     """
     policy: dict[str, Any] = {
-        "@context": "http://www.w3.org/ns/odrl.jsonld",
         "@type": "odrl:Offer",
         "@id": offer_id,
         "assigner": assigner,
@@ -340,8 +351,12 @@ async def initiate_contract_negotiation(
         policy["odrl:obligation"] = obligation
 
     payload: dict[str, Any] = {
-        "@context": {"@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
-        "@type": "https://w3id.org/edc/v0.0.1/ns/ContractRequest",
+        "@context": [
+            "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+            "https://w3id.org/catenax/2025/9/policy/context.jsonld",
+            {"@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
+        ],
+        "@type": "ContractRequest",
         "counterPartyAddress": counter_party_address,
         "protocol": protocol,
         "policy": policy,
@@ -353,25 +368,27 @@ async def initiate_contract_negotiation(
 
 
 @mcp.tool()
-async def get_negotiation_state(
+async def get_contract_negotiation(
     negotiation_id: str,
 ) -> dict[str, Any]:
     """
     Get the state of a contract negotiation.
 
     Use this to poll the progress of an asynchronous contract negotiation.
+    Returns the full negotiation object including state, contractAgreementId,
+    and errorDetail (if terminated).
     Common states: REQUESTED, AGREED, VERIFIED, FINALIZED, TERMINATED.
 
     Args:
         negotiation_id: The ID returned by initiate_contract_negotiation
 
     Returns:
-        The current negotiation state
+        The full contract negotiation object including state and agreement ID
 
     Example:
-        get_negotiation_state(negotiation_id="negotiation-id")
+        get_contract_negotiation(negotiation_id="negotiation-id")
     """
-    return await _api_request("GET", f"/v3/contractnegotiations/{negotiation_id}/state")
+    return await _api_request("GET", f"/v3/contractnegotiations/{negotiation_id}")
 
 
 @mcp.tool()
@@ -411,7 +428,7 @@ async def initiate_transfer(
     """
     Initiate a data transfer using a contract agreement.
 
-    Starts an asynchronous transfer process. Poll get_transfer_state to track progress.
+    Starts an asynchronous transfer process. Poll get_transfer_process to track progress.
     For HTTP pull transfers, use transfer_type="HttpData-PULL" and no data_destination.
     After the transfer reaches STARTED state, use get_edr_data_address to get the access token.
 
@@ -435,7 +452,7 @@ async def initiate_transfer(
     """
     payload: dict[str, Any] = {
         "@context": {"@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
-        "@type": "https://w3id.org/edc/v0.0.1/ns/TransferRequest",
+        "@type": "TransferRequest",
         "counterPartyAddress": counter_party_address,
         "contractId": contract_id,
         "transferType": transfer_type,
@@ -446,7 +463,7 @@ async def initiate_transfer(
     else:
         # EDC requires a dataDestination even for PULL transfers to avoid NPE
         # in resource definition generators. HttpProxy signals a client-pull.
-        payload["dataDestination"] = {"@type": "https://w3id.org/edc/v0.0.1/ns/DataAddress", "type": "HttpProxy"}
+        payload["dataDestination"] = {"@type": "DataAddress", "type": "HttpProxy"}
     if callback_addresses:
         payload["callbackAddresses"] = callback_addresses
 
@@ -454,25 +471,27 @@ async def initiate_transfer(
 
 
 @mcp.tool()
-async def get_transfer_state(
+async def get_transfer_process(
     transfer_process_id: str,
 ) -> dict[str, Any]:
     """
     Get the state of a transfer process.
 
     Use this to poll the progress of an asynchronous data transfer.
+    Returns the full transfer process object including state, correlationId,
+    and errorDetail (if terminated).
     Common states: REQUESTED, STARTED, COMPLETED, TERMINATED, SUSPENDED.
 
     Args:
         transfer_process_id: The ID returned by initiate_transfer
 
     Returns:
-        The current transfer process state
+        The full transfer process object including state and error details
 
     Example:
-        get_transfer_state(transfer_process_id="transfer-id")
+        get_transfer_process(transfer_process_id="transfer-id")
     """
-    return await _api_request("GET", f"/v3/transferprocesses/{transfer_process_id}/state")
+    return await _api_request("GET", f"/v3/transferprocesses/{transfer_process_id}")
 
 
 # --- EDR Cache ---
@@ -498,7 +517,83 @@ async def get_edr_data_address(
     Example:
         get_edr_data_address(transfer_process_id="transfer-id")
     """
-    return await _api_request("GET", f"/v2/edrs/{transfer_process_id}/dataaddress")
+    return await _api_request("GET", f"/v3/edrs/{transfer_process_id}/dataaddress")
+
+
+@mcp.tool()
+async def initiate_edr_negotiation(
+    counter_party_address: str,
+    offer_id: str,
+    asset_id: str,
+    assigner: str,
+    protocol: str = "dataspace-protocol-http",
+    permission: Optional[list[dict[str, Any]]] = None,
+    prohibition: Optional[list[dict[str, Any]]] = None,
+    obligation: Optional[list[dict[str, Any]]] = None,
+    callback_addresses: Optional[list[dict[str, Any]]] = None,
+) -> dict[str, Any]:
+    """
+    Initiate an EDR negotiation that combines contract negotiation and transfer in one call.
+
+    This is a convenience shortcut that handles the full flow: contract negotiation,
+    followed by an automatic HttpData-PULL transfer. Once the negotiation finalizes
+    and the transfer starts, the EDR becomes available via get_edr_data_address.
+
+    Poll get_contract_negotiation with the returned negotiation ID to track progress.
+
+    Args:
+        counter_party_address: The DSP endpoint URL of the provider connector
+        offer_id: The offer/policy ID from the catalog (the "@id" of the odrl:hasPolicy)
+        asset_id: The target asset ID from the catalog offer
+        assigner: The provider participant ID (assigner of the offer)
+        protocol: Protocol to use (default: "dataspace-protocol-http")
+        permission: The permission array from the catalog offer's odrl:hasPolicy (pass it through exactly)
+        prohibition: The prohibition array from the catalog offer's odrl:hasPolicy (pass it through exactly)
+        obligation: The obligation array from the catalog offer's odrl:hasPolicy (pass it through exactly)
+        callback_addresses: Optional webhook addresses for negotiation events
+
+    Returns:
+        Response with negotiation ID and created timestamp
+
+    Example:
+        initiate_edr_negotiation(
+            counter_party_address="https://provider.example.com/dsp",
+            offer_id="offer-id-from-catalog",
+            asset_id="asset-id",
+            assigner="provider-participant-id",
+            permission=[{"action": "use"}],
+            prohibition=[],
+            obligation=[]
+        )
+    """
+    policy: dict[str, Any] = {
+        "@type": "odrl:Offer",
+        "@id": offer_id,
+        "assigner": assigner,
+        "target": asset_id,
+    }
+    if permission is not None:
+        policy["odrl:permission"] = permission
+    if prohibition is not None:
+        policy["odrl:prohibition"] = prohibition
+    if obligation is not None:
+        policy["odrl:obligation"] = obligation
+
+    payload: dict[str, Any] = {
+        "@context": [
+            "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+            "https://w3id.org/catenax/2025/9/policy/context.jsonld",
+            {"@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
+        ],
+        "@type": "ContractRequest",
+        "counterPartyAddress": counter_party_address,
+        "protocol": protocol,
+        "policy": policy,
+    }
+    if callback_addresses:
+        payload["callbackAddresses"] = callback_addresses
+
+    return await _api_request("POST", "/v3/edrs", payload)
 
 
 # --- Query Tools ---
@@ -514,7 +609,7 @@ def _build_query_spec(
     """Build a QuerySpec payload."""
     spec: dict[str, Any] = {
         "@context": {"@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
-        "@type": "https://w3id.org/edc/v0.0.1/ns/QuerySpec",
+        "@type": "QuerySpec",
         "offset": offset,
         "limit": limit,
         "sortOrder": sort_order,


### PR DESCRIPTION
## Summary

Upgrades the connector from the previous Tractus-X EDC version to 0.11.2, which pulls in Eclipse EDC 0.14.0 (Saturn). This is a breaking upgrade that required changes across the EDC extensions, CDK infrastructure, and API Gateway definitions.

## Changes

### EDC Extensions
- Bump dependency versions in `libs.versions.toml` (Tractus-X 0.11.x, EDC 0.14.x, EDC-AWS 0.11.x)
- Update DDB extension stores for new EDC SPI interfaces
- Add `log4j2.json`/`log4j2.xml` to override upstream Root=OFF logging default

### CDK Infrastructure
- Rename `web.http.default.port`/`path` to `web.http.port`/`path` (renamed in EDC 0.14.0)
- Align all web context paths to upstream defaults (`/api/management`, `/api/control`, `/api/protocol`, `/api/public`)
- Update port mappings to EDC 0.14.0 defaults (8181, 8182, 9191, 8282)
- Remove obsolete `observability` web context (now served on the default context)
- Remove deprecated `edc.api.auth.key` setting
- Add `tractusx.edc.participant.bpn` environment variable (required by Tractus-X 0.11.x)
- Add missing `BusinessPartnerGroups` DynamoDB table
- Relax NLB health check thresholds for container startup tolerance

### API Gateway Specs
- Regenerate `management-api.yaml` for Management API v3.1.3 (EDR endpoints moved from v2 to v3, new policy validation endpoints)
- Regenerate `dsp-api.yaml` for DSP protocol v0.14.0 (add versioned `2024/1` and `2025-1` path prefixes)
- Strip incompatible schema names and null values from upstream specs for API Gateway compatibility

## Testing

Deployed to `us-west-2` and validated:
- ✅ Both control plane and data plane ECS services healthy
- ✅ Management API: created assets, policies, and contract definitions
- ✅ DSP Protocol API: catalog requests return valid DCAT responses
- ✅ DynamoDB persistence working
- ✅ Contract negotiation flow executes end-to-end (terminated by CX policy evaluation as expected in self-test)